### PR TITLE
get rid of --path for terraform, as path is always required and not a…

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -48,6 +48,10 @@ runs:
           echo "When setting the 'scan_type' to 'docker_image_from_dockerfile' you must also specify the 'path' input value. Cannot continue."
           exit 1
         fi
+        if [[ "${{ inputs.scan_type }}" == "terraform" ]] && [[ -z "${{ inputs.path }}" ]]; then
+          echo "When setting the 'scan_type' to 'terraform' you must also specify the 'path' input value. Cannot continue."
+          exit 1
+        fi
         if [[ ! "${{ inputs.output_format }}" =~ ^compact$|^full$|^csv$|^json$|^junit$|^yaml$ ]]; then
           echo "Valid 'output_format' input values are 'compact', 'full', 'csv', 'json', 'junit', or 'yaml'. Cannot continue."
           exit 1
@@ -68,6 +72,8 @@ runs:
         echo Building mondoo-test-image from Dockerfile...
         docker build . --file ${{ inputs.path }} --tag mondoo-test-image
       if: inputs.scan_type == 'docker_image_from_dockerfile'
+    
+    # Only run for docker images or images from dockerfile
     - name: Scan docker container
       shell: bash
       run: |
@@ -78,14 +84,22 @@ runs:
 
         echo Scanning Docker container ${CONTAINER_IMAGE} with Mondoo Client...
         mondoo scan --detect-cicd docker://${CONTAINER_IMAGE} --config mondoo.json --score-threshold ${{ inputs.score_threshold }} --output ${{ inputs.output_format }} ${{ inputs.extra_args }}
-      if: inputs.scan_type == 'docker_image_from_dockerfile' || inputs.scan_type == 'docker_image'
-    - name: Scan configs
+      if: inputs.scan_type == ^docker_image$|^docker_image_from_dockerfile$ && inputs.scan_type != ^k8s$|^terraform$
+    # Only run on k8s manifests, where ```--path``` is required for manifests.
+    - name: Scan k8s manifest
       shell: bash
       run: |
         echo Scanning ${{ inputs.path }} with Mondoo Client...
         mondoo scan --detect-cicd ${{ inputs.scan_type }} --path ${{ inputs.path }} --config mondoo.json --score-threshold ${{ inputs.score_threshold }} --output ${{ inputs.output_format }} ${{ inputs.extra_args }}
-      if: inputs.scan_type != 'docker_image_from_dockerfile' && inputs.scan_type != 'docker_image'
-          
+      if: inputs.scan_type == 'k8s' && inputs.scan_type != ^docker_image$|^docker_image_from_dockerfile$|^terraform$
+    # Only run on Terraform manifests, where a path is required and ```--path``` isn't supported.
+    - name: Scan Terraform configuration files
+      shell: bash
+      run: |
+        echo Scanning ${{ inputs.path }} with Mondoo Client...
+        mondoo scan --detect-cicd ${{ inputs.scan_type }} ${{ inputs.path }} --config mondoo.json --score-threshold ${{ inputs.score_threshold }} --output ${{ inputs.output_format }} ${{ inputs.extra_args }}
+      if: inputs.scan_type == 'terraform' && inputs.scan_type != ^docker_image$|^docker_image_from_dockerfile$|^k8s$
+
 branding:
   icon: 'shield'
   color: 'purple'


### PR DESCRIPTION
Fixes a few things
- Adds a condition to quit if there is no path set when using terraform
- Breaks out the previous command used for manifests and terraform into two
- Be specific about which scan_types run which step

Signed-off-by: yvovandoorn <yvo.vandoorn@gmail.com>