### PR TITLE
⭐️ Add workflow to automatically create Github release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,17 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Create release
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
I noticed that you are creating and filling the Github release manually. With this PR you can just push a tag and the release will be created for you. It will also add the titles of all the merged PRs since the latest release. We use this for the operator and it looks like [this](https://github.com/mondoohq/mondoo-operator/releases/tag/v1.1.1)