### PR TITLE
Cleanups from 0.5.0 mega release

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - 
         name: Checkout 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -41,5 +41,5 @@ jobs:
         name: Scan Docker Image
         uses: ./docker-image
         with:
-          service-account-credentials: ${{ secrets.MONDOO_CLIENT_ACCOUNT }}
+          service-account-credentials: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
           image: ${{env.APP}}:${{env.VERSION}}

--- a/.github/workflows/k8s-manifest.yaml
+++ b/.github/workflows/k8s-manifest.yaml
@@ -21,5 +21,5 @@ jobs:
       - name: Scan k8s manifest
         uses: ./k8s-manifest
         with:
-          service-account-credentials: ${{ secrets.MONDOO_CLIENT_ACCOUNT }}
+          service-account-credentials: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
           path: ./.github/test_files/k8s-manifest.yaml

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -21,5 +21,5 @@ jobs:
       - name: Scan Terraform 
         uses: ./terraform
         with:
-          service-account-credentials: ${{ secrets.MONDOO_CLIENT_ACCOUNT }}
+          service-account-credentials: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
           path: ./.github/test_files/tf

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ jobs:
   install:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: mondoohq/actions/kubernetes@master
+    - uses: actions/checkout@v3
+    - uses: mondoohq/actions/kubernetes@main
       with:
         service-account-credentials: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         path: k8s/*.yaml
@@ -64,9 +64,9 @@ on:
     - 'terraform/main.tf'
 jobs:
   steps:
-  - uses: actions/checkout@master
+  - uses: actions/checkout@v3
   
-  - uses: mondoohq/actions/terraform@master
+  - uses: mondoohq/actions/terraform@main
     with:
       service-account-credentials: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
       path: terraform
@@ -90,7 +90,7 @@ jobs:
     steps:
       - 
         name: Checkout 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -117,7 +117,7 @@ jobs:
             GIT_AUTH_TOKEN=${{ secrets.GIT_AUTH_TOKEN }}
       -
         name: Scan Docker Image with Mondoo
-        uses: mondoohq/actions/docker-image@master
+        uses: mondoohq/actions/docker-image@main
         with:
           service-account-credentials: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
           image: ghcr.io/${{github.repository_owner}}/${{env.APP}}:latest

--- a/aws/README.md
+++ b/aws/README.md
@@ -26,7 +26,7 @@ jobs:
   scan-aws-account:
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -35,7 +35,7 @@ jobs:
         role-to-assume: arn:aws:iam::123456789100:role/my-github-actions-role
         role-session-name: MySessionName
 
-    - uses: mondoohq/actions/aws@master
+    - uses: mondoohq/actions/aws@main
       with:
         service-account-credentials: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         output: compact

--- a/docker-image/README.md
+++ b/docker-image/README.md
@@ -37,7 +37,7 @@ jobs:
     steps:
       - 
         name: Checkout 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -64,7 +64,7 @@ jobs:
             GIT_AUTH_TOKEN=${{ secrets.GIT_AUTH_TOKEN }}
       -
         name: Scan Docker Image
-        uses: mondoohq/actions/docker-image@master
+        uses: mondoohq/actions/docker-image@main
         with:
           service-account-credentials: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
           image: ghcr.io/${{github.repository_owner}}/${{env.APP}}:latest

--- a/k8s-manifest/README.md
+++ b/k8s-manifest/README.md
@@ -31,8 +31,8 @@ jobs:
   install:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: mondoohq/actions/k8s-manifest@master
+    - uses: actions/checkout@v3
+    - uses: mondoohq/actions/k8s-manifest@main
       with:
         service-account-credentials: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         path: k8s/deployment.yaml

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -30,8 +30,8 @@ jobs:
   scan-k8s-cluster:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: mondoohq/actions/k8s@master
+    - uses: actions/checkout@v3
+    - uses: mondoohq/actions/k8s@main
       with:
         service-account-credentials: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
 ```

--- a/policy/README.md
+++ b/policy/README.md
@@ -34,8 +34,8 @@ jobs:
   install:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: mondoohq/actions/policy@master
+    - uses: actions/checkout@v3
+    - uses: mondoohq/actions/policy@main
       with:
         service-account-credentials: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         path: policy/policy.yml

--- a/setup/README.md
+++ b/setup/README.md
@@ -24,9 +24,9 @@ jobs:
   install:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
 
-    - uses: mondoohq/actions/setup@master
+    - uses: mondoohq/actions/setup@main
       with:
         service_account_credentials: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         args: status

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -28,8 +28,8 @@ on:
 jobs:
   
     steps:
-    - uses: actions/checkout@master
-    - uses: mondoohq/actions/terraform@master
+    - uses: actions/checkout@v3
+    - uses: mondoohq/actions/terraform@main
       with:
         service-account-credentials: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         path: terraform


### PR DESCRIPTION
A few clean ups!

- replace Mondoo Actions `master` with `main`
- Use `actions/checkout@v3` instead of `master` in docs as Github doesn't expose the default branch as something you can use in your action. 
- Use `actions/checkout@v3` where `v2` was being used
- We changed our example variable from `MONDOO_CLIENT_ACCOUNT` to `MONDOO_SERVICE_ACCOUNT`, we should use that as well to avoid confusion. #FollowOurOwnExamples

Signed-off-by: yvovandoorn <yvo.vandoorn@gmail.com>