### PR TITLE
🧹 Bump spell-checking to 0.0.21

### DIFF
--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: check-spelling
         id: spelling
-        uses: check-spelling/check-spelling@v0.0.20
+        uses: check-spelling/check-spelling@v0.0.21
         with:
           suppress_push_for_open_pull_request: 1
           checkout: true


### PR DESCRIPTION
Because of an security advisory for version 0.0.20: 'Upgrade now, see https://github.com/check-spelling/check-spelling/security/advisories/GHSA-p8r9-69g4-jwqq'

Signed-off-by: Christian Zunker <christian@mondoo.com>