### PR TITLE
⭐️ cnspec lint action

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,2 +1,4 @@
 buildx
 myapp
+codeql
+chrisrock

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,4 +1,3 @@
 buildx
 myapp
 codeql
-chrisrock

--- a/.github/test_files/cnspec-lint/lint.mql.yaml
+++ b/.github/test_files/cnspec-lint/lint.mql.yaml
@@ -1,0 +1,40 @@
+policies:
+  - uid: pol # too short uid
+    name: Policy 1
+    version: "1.0.0"
+    authors:
+      - name: Jane Doe
+        email: jane@example.com
+    tags:
+      key: value
+      another-key: another-value
+    specs:
+      - asset_filter:
+          query: platform.family.contains(_ == 'unix')
+        scoring_queries:
+          query1:
+          query2:
+          query3: # missing implementation
+  - uid: policy-2 # missing name
+    version: "x.y.z" # invalid semver
+    specs: # empty spec
+
+queries:
+  - uid: query1
+    title: Ensure SSH MaxAuthTries is set to 4 or less
+    query: sshd.config.params["MaxAuthTries"] <= 4
+    docs:
+      desc: |
+        The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection.
+        When the login failure count reaches half the number, error messages will be written to the syslog file
+        detailing the login failure.
+      audit: Run the `sshd -T | grep maxauthtries` command and verify that output MaxAuthTries is 4 or less
+      remediation: |
+        Open your `/etc/ssh/sshd_config` and set `MaxAuthTries` to `4`.
+    refs:
+      - title: CIS Distribution Independent Linux
+        url: https://www.cisecurity.org/benchmark/distribution_independent_linux/
+  - uid: query2
+  - uid: query4 # not assigned
+    title: Ensure SSH Protocol is set to 2
+    query: sshd.config.params["Protocol"] == 2

--- a/.github/workflows/cnspec-lint.yaml
+++ b/.github/workflows/cnspec-lint.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           path: ./.github/test_files/cnspec-lint
           output-file: "custom-results.sarif"
-      - name: Archive sarif results
+      - name: Archive SARIF results
         uses: actions/upload-artifact@v3
         with:
           name: cnspec-lint-report

--- a/.github/workflows/cnspec-lint.yaml
+++ b/.github/workflows/cnspec-lint.yaml
@@ -16,9 +16,9 @@ jobs:
         uses: ./cnspec-lint
         with:
           path: ./.github/test_files/cnspec-lint
-          output: "results.sarif"
+          output-file: "custom-results.sarif"
       - name: Archive sarif results
         uses: actions/upload-artifact@v3
         with:
           name: cnspec-lint-report
-          path: results.sarif
+          path: custom-results.sarif

--- a/.github/workflows/cnspec-lint.yaml
+++ b/.github/workflows/cnspec-lint.yaml
@@ -1,0 +1,24 @@
+name: Test cnspec policy linting
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Lint Policies
+        uses: ./cnspec-lint
+        with:
+          path: ./.github/test_files/cnspec-lint
+          output: "results.sarif"
+      - name: Archive sarif results
+        uses: actions/upload-artifact@v3
+        with:
+          name: cnspec-lint-report
+          path: results.sarif

--- a/cnspec-lint/README.md
+++ b/cnspec-lint/README.md
@@ -1,0 +1,42 @@
+# Mondoo cnspec lint Action
+
+A [GitHub Action](https://github.com/features/actions) for testing [HashiCorp Terraform](https://terraform.io) [HCL code](https://www.terraform.io/language/syntax/configuration) for security misconfigurations.
+
+## Properties
+
+The cnspec lint Action has properties that are passed to the action using `with`.
+
+| Property      | Required | Default         | Description                                           |
+| ------------- | -------- | --------------- | ----------------------------------------------------- |
+| `path`        | true     | `.`             | Specifies the root path of the bundles .              |
+| `output-path` | true     | `results.sarif` | Specifies the output path for the sarif report file'. |
+
+## Scan policy bundles for lint errors
+
+You can use the Action as follows:
+
+```yaml
+name: Lint Policies
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Lint Policies
+        uses: github/mondoohq/actions/cnspec-lint
+        with:
+          path: .
+          output: "results.sarif"
+      - name: Upload SARIF results file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: results.sarif
+```

--- a/cnspec-lint/README.md
+++ b/cnspec-lint/README.md
@@ -1,6 +1,6 @@
 # Mondoo cnspec lint Action
 
-A [GitHub Action](https://github.com/features/actions) for linting cnspec policy bundles with Sarif output.
+A [GitHub Action](https://github.com/features/actions) for linting cnspec policy bundles with SARIF output.
 
 ## Properties
 
@@ -9,7 +9,7 @@ The cnspec lint Action has properties that are passed to the action using `with`
 | Property      | Required | Default         | Description                                           |
 | ------------- | -------- | --------------- | ----------------------------------------------------- |
 | `path`        | true     | `.`             | Specifies the root path of the bundles .              |
-| `output-file` | true     | `results.sarif` | Specifies the output path for the sarif report file'. |
+| `output-file` | true     | `results.sarif` | Specifies the output path for the SARIF report file'. |
 
 ## Scan policy bundles for lint errors
 

--- a/cnspec-lint/README.md
+++ b/cnspec-lint/README.md
@@ -1,6 +1,6 @@
 # Mondoo cnspec lint Action
 
-A [GitHub Action](https://github.com/features/actions) for testing [HashiCorp Terraform](https://terraform.io) [HCL code](https://www.terraform.io/language/syntax/configuration) for security misconfigurations.
+A [GitHub Action](https://github.com/features/actions) for linting cnspec policy bundles with Sarif output.
 
 ## Properties
 
@@ -9,7 +9,7 @@ The cnspec lint Action has properties that are passed to the action using `with`
 | Property      | Required | Default         | Description                                           |
 | ------------- | -------- | --------------- | ----------------------------------------------------- |
 | `path`        | true     | `.`             | Specifies the root path of the bundles .              |
-| `output-path` | true     | `results.sarif` | Specifies the output path for the sarif report file'. |
+| `output-file` | true     | `results.sarif` | Specifies the output path for the sarif report file'. |
 
 ## Scan policy bundles for lint errors
 
@@ -34,7 +34,7 @@ jobs:
         uses: github/mondoohq/actions/cnspec-lint
         with:
           path: .
-          output: "results.sarif"
+          output-file: "results.sarif"
       - name: Upload SARIF results file
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/cnspec-lint/action.yaml
+++ b/cnspec-lint/action.yaml
@@ -15,7 +15,7 @@ inputs:
     default: "results.sarif"
 runs:
   using: "docker"
-  image: "chrisrock/cnspec:latest"
+  image: "mondoo/cnspec:7"
   args:
     - bundle
     - lint

--- a/cnspec-lint/action.yaml
+++ b/cnspec-lint/action.yaml
@@ -1,0 +1,26 @@
+name: "Lint cnspec policies"
+author: "mondoohq"
+description: "This action runs `cnspec bundle lint` and outputs the results as Sarif report so that the results can easily be shows in GitHub code scanning results"
+branding:
+  icon: "shield"
+  color: "purple"
+inputs:
+  path:
+    description: "Specifies the root path of the bundles"
+    required: true
+    default: "."
+  output-file:
+    description: "Specifies the output path for the sarif report file"
+    required: true
+    default: "results.sarif"
+runs:
+  using: "docker"
+  image: "chrisrock/cnspec:latest"
+  args:
+    - bundle
+    - lint
+    - ${{ inputs.path }}
+    - --output
+    - sarif
+    - --output-file
+    - ${{ inputs.output-file }}

--- a/cnspec-lint/action.yaml
+++ b/cnspec-lint/action.yaml
@@ -1,6 +1,6 @@
 name: "Lint cnspec policies"
 author: "mondoohq"
-description: "This action runs `cnspec bundle lint` and outputs the results as Sarif report so that the results can easily be shows in GitHub code scanning results"
+description: "This action runs `cnspec bundle lint` and outputs the results as SARIF report so that the results can easily be shown in GitHub code scanning results"
 branding:
   icon: "shield"
   color: "purple"
@@ -10,7 +10,7 @@ inputs:
     required: true
     default: "."
   output-file:
-    description: "Specifies the output path for the sarif report file"
+    description: "Specifies the output path for the SARIF report file"
     required: true
     default: "results.sarif"
 runs:


### PR DESCRIPTION
**Problem:**

As a user I want to easily validate that my policy bundles are written correctly

**Solution:**

The new `mondoohq/actions/cnspec-lint` action allows users to quickly identify issues with their policy bundle and fix them accordingly.

This action depends on https://github.com/mondoohq/cnspec/pull/253 to be merged and released first

