### PR TITLE
Updates setup-terraform version on tfplan README

### DIFF
--- a/terraform-plan/README.md
+++ b/terraform-plan/README.md
@@ -41,7 +41,7 @@ jobs:
   generate-and-scan-terraform-plan:
     steps:
       - uses: actions/checkout@v3
-    - uses: hashicorp/setup-terraform@v2
+    - uses: hashicorp/setup-terraform@v3
       with:
         terraform_wrapper: false
 


### PR DESCRIPTION
This PR updates the Terraform Plan Action readme to use `setup-terraform@v3` due to an issue with generating the plan file in `v2`