### PR TITLE
✨ add `image-tag` input to `cnspec-lint` action

### DIFF
--- a/.github/workflows/cnspec-lint.yaml
+++ b/.github/workflows/cnspec-lint.yaml
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  build:
+  build-11:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -17,6 +17,22 @@ jobs:
         with:
           path: ./.github/test_files/cnspec-lint
           output-file: "custom-results.sarif"
+      - name: Archive SARIF results
+        uses: actions/upload-artifact@v4
+        with:
+          name: cnspec-lint-report
+          path: custom-results.sarif
+  build-edge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Lint Policies
+        uses: ./cnspec-lint
+        with:
+          path: ./.github/test_files/cnspec-lint
+          output-file: "custom-results.sarif"
+          image-tag: "edge-latest"
       - name: Archive SARIF results
         uses: actions/upload-artifact@v4
         with:

--- a/cnspec-lint/action.yaml
+++ b/cnspec-lint/action.yaml
@@ -13,9 +13,18 @@ inputs:
     description: "Specifies the output path for the SARIF report file"
     required: true
     default: "results.sarif"
+  image-tag:
+    description: "Select the Docker image tag to use from mondoo/cnspec repository"
+    required: true
+    default: "11"
+    options:
+      - "11"
+      - "edge-latest"
+      - "latest"
+
 runs:
   using: "docker"
-  image: "docker://mondoo/cnspec:11"
+  image: "docker://mondoo/cnspec:${{ inputs.image-tag }}"
   args:
     - bundle
     - lint


### PR DESCRIPTION
This should allow us to switch to our `edge-latest` tag for testing when we release
our `cnspec` binary containing the linter.