### PR TITLE
🧹 improve lint task

### DIFF
--- a/cnspec-lint/action.yaml
+++ b/cnspec-lint/action.yaml
@@ -15,9 +15,9 @@ inputs:
     default: "results.sarif"
 runs:
   using: "docker"
-  image: "docker://mondoo/cnspec:12"
+  image: "docker://mondoo/cnspec:12.2.0"
   args:
-    - bundle
+    - policy
     - lint
     - ${{ inputs.path }}
     - --output


### PR DESCRIPTION
- switch to latest 12.2
- switches to `cnspec policy lint` since `cnspec bundle lint` is deprecated