### PR TITLE
Update cnspec from 12 to 13

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,6 @@ runs:
     - run: echo "MONDOO_CONFIG_BASE64=${{ inputs.service-account-credentials }}" >> $GITHUB_ENV
       if: env.MONDOO_CONFIG_BASE64 == ''
       shell: bash
-    - uses: "docker://mondoo/cnspec:12"
+    - uses: "docker://mondoo/cnspec:13"
       with:
         args: ${{ inputs.args }} --log-level "${{ inputs.log-level }}"

--- a/aws/action.yaml
+++ b/aws/action.yaml
@@ -25,7 +25,7 @@ inputs:
     required: false
 runs:
   using: "docker"
-  image: "docker://mondoo/cnspec:12"
+  image: "docker://mondoo/cnspec:13"
   args:
     - scan
     - aws

--- a/cnspec-lint/action.yaml
+++ b/cnspec-lint/action.yaml
@@ -15,7 +15,7 @@ inputs:
     default: "results.sarif"
 runs:
   using: "docker"
-  image: "docker://mondoo/cnspec:12"
+  image: "docker://mondoo/cnspec:13"
   args:
     - policy
     - lint

--- a/docker-image/action.yaml
+++ b/docker-image/action.yaml
@@ -27,7 +27,7 @@ inputs:
     required: false
 runs:
   using: "docker"
-  image: "docker://mondoo/cnspec:12"
+  image: "docker://mondoo/cnspec:13"
   args:
     - scan
     - docker

--- a/github-org/action.yaml
+++ b/github-org/action.yaml
@@ -30,7 +30,7 @@ inputs:
     required: false
 runs:
   using: "docker"
-  image: "docker://mondoo/cnspec:12"
+  image: "docker://mondoo/cnspec:13"
   args:
     - scan
     - github

--- a/github-repo/action.yaml
+++ b/github-repo/action.yaml
@@ -30,7 +30,7 @@ inputs:
     required: false
 runs:
   using: "docker"
-  image: "docker://mondoo/cnspec:12"
+  image: "docker://mondoo/cnspec:13"
   args:
     - scan
     - github

--- a/k8s-manifest/action.yaml
+++ b/k8s-manifest/action.yaml
@@ -27,7 +27,7 @@ inputs:
     required: false
 runs:
   using: "docker"
-  image: "docker://mondoo/cnspec:12"
+  image: "docker://mondoo/cnspec:13"
   args:
     - scan
     - k8s

--- a/k8s/action.yaml
+++ b/k8s/action.yaml
@@ -24,7 +24,7 @@ inputs:
     required: false
 runs:
   using: "docker"
-  image: "docker://mondoo/cnspec:12"
+  image: "docker://mondoo/cnspec:13"
   args:
     - scan
     - k8s

--- a/policy/action.yaml
+++ b/policy/action.yaml
@@ -22,7 +22,7 @@ inputs:
     required: false
 runs:
   using: "docker"
-  image: "docker://mondoo/cnspec:12"
+  image: "docker://mondoo/cnspec:13"
   args:
     - bundle
     - upload

--- a/terraform-hcl/action.yaml
+++ b/terraform-hcl/action.yaml
@@ -27,7 +27,7 @@ inputs:
     required: false
 runs:
   using: "docker"
-  image: "docker://mondoo/cnspec:12"
+  image: "docker://mondoo/cnspec:13"
   args:
     - scan
     - terraform

--- a/terraform-plan/action.yaml
+++ b/terraform-plan/action.yaml
@@ -32,7 +32,7 @@ inputs:
     required: false
 runs:
   using: "docker"
-  image: "docker://mondoo/cnspec:12"
+  image: "docker://mondoo/cnspec:13"
   args:
     - scan
     - terraform

--- a/terraform-state/action.yaml
+++ b/terraform-state/action.yaml
@@ -27,7 +27,7 @@ inputs:
     required: false
 runs:
   using: "docker"
-  image: "docker://mondoo/cnspec:12"
+  image: "docker://mondoo/cnspec:13"
   args:
     - scan
     - terraform


### PR DESCRIPTION
## Summary
- Bump `mondoo/cnspec` container image tag from `12` to `13` across all 12 action definitions

## Test plan
- [ ] Verify actions pull the correct cnspec 13 image
- [ ] Run a scan with each action to confirm compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)