### PR TITLE
✨ Add reusable workflow for updating pinned tool versions

### DIFF
--- a/.github/workflows/update-pinned-versions.yml
+++ b/.github/workflows/update-pinned-versions.yml
@@ -1,0 +1,210 @@
+# Reusable workflow: Update pinned tool versions
+#
+# Scans workflow files for `# auto-update:` annotations and opens a PR
+# when newer versions are available.
+#
+# Annotation format (place directly above the version line):
+#   # auto-update: source=github-releases repo=owner/repo
+#   version: v1.2.3
+#
+# Requirements:
+#   - The version must be strict semver (v0.0.0), no pre-release suffixes
+#   - The version must appear exactly once on the line following the annotation
+#   - Only github-releases (not raw tags) are supported as a source
+#
+# Usage in a caller workflow:
+#   jobs:
+#     update-versions:
+#       uses: mondoohq/actions/.github/workflows/update-pinned-versions.yml@main
+#       permissions:
+#         contents: write
+#         pull-requests: write
+#       secrets:
+#         ssh-key: ${{ secrets.DEPLOY_KEY }}
+#
+# Or without an SSH deploy key (uses GITHUB_TOKEN, PRs won't trigger other workflows):
+#   jobs:
+#     update-versions:
+#       uses: mondoohq/actions/.github/workflows/update-pinned-versions.yml@main
+#       permissions:
+#         contents: write
+#         pull-requests: write
+
+name: Update pinned tool versions
+
+on:
+  workflow_call:
+    inputs:
+      scan-path:
+        description: "Directory to scan for annotations (default: .github/)"
+        required: false
+        default: ".github/"
+        type: string
+      base-branch:
+        description: "Base branch for the PR"
+        required: false
+        default: "main"
+        type: string
+      pr-branch:
+        description: "Branch name for the PR"
+        required: false
+        default: "version/pinned-tools-update"
+        type: string
+      committer-name:
+        description: "Git committer name"
+        required: false
+        default: "github-actions[bot]"
+        type: string
+      committer-email:
+        description: "Git committer email"
+        required: false
+        default: "41898282+github-actions[bot]@users.noreply.github.com"
+        type: string
+    secrets:
+      ssh-key:
+        description: "SSH deploy key for pushing (optional, falls back to GITHUB_TOKEN)"
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  update-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ssh-key: ${{ secrets.ssh-key || '' }}
+
+      - name: Scan for annotated versions and update
+        id: scan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SCAN_PATH: ${{ inputs.scan-path }}
+        run: |
+          set -euo pipefail
+
+          # Strict semver pattern used for both current and latest validation
+          SEMVER_RE='^v[0-9]+\.[0-9]+\.[0-9]+$'
+
+          # Temp file for collecting updates across iterations. Cleaned up on
+          # exit via trap. All reads (apply + summary) happen in this same run:
+          # block before the shell exits, so the file is always available.
+          UPDATES_FILE=$(mktemp)
+          trap 'rm -f "$UPDATES_FILE"' EXIT
+
+          # Find all auto-update annotations.
+          # Use process substitution to keep the loop in the current shell,
+          # so writes to UPDATES_FILE are visible after the loop.
+          while IFS=: read -r file lineno _; do
+            annotation=$(sed -n "${lineno}p" "$file")
+            repo=$(echo "$annotation" | grep -oP '# auto-update: source=github-releases repo=\K\S+')
+
+            if [ -z "$repo" ] || ! [[ "$repo" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+              echo "::warning::Invalid or malformed annotation on line ${lineno} of ${file}: repo=${repo}"
+              continue
+            fi
+
+            next_lineno=$((lineno + 1))
+            version_line=$(sed -n "${next_lineno}p" "$file")
+            # Extract the version value from the line. Uses tail -1 to grab the
+            # last semver match, skipping any versions in comments or hashes that
+            # may appear earlier on the line (e.g., "version: v2.0.0 # was v1.9.0").
+            current=$(echo "$version_line" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
+
+            if [ -z "$current" ]; then
+              echo "::warning::No version found on line ${next_lineno} of ${file} (annotation for ${repo})"
+              continue
+            fi
+            if ! [[ "$current" =~ $SEMVER_RE ]]; then
+              echo "::warning::Current version '${current}' on line ${next_lineno} of ${file} is not strict semver, skipping"
+              continue
+            fi
+
+            # Fetch latest release. Separate HTTP/auth errors from empty responses.
+            api_output=$(gh api "repos/${repo}/releases/latest" --jq '.tag_name' 2>&1) || {
+              echo "::warning::API error fetching latest release for ${repo}: ${api_output}"
+              continue
+            }
+            latest="$api_output"
+            if [ -z "$latest" ]; then
+              echo "::warning::No release found for ${repo} (repo may only use tags, not releases)"
+              continue
+            fi
+            if ! [[ "$latest" =~ $SEMVER_RE ]]; then
+              echo "::warning::Latest version '${latest}' for ${repo} is not strict semver, skipping"
+              continue
+            fi
+
+            # Only update if latest is actually newer (avoids downgrade PRs on rollbacks)
+            newest=$(printf '%s\n%s' "$current" "$latest" | sort -V | tail -1)
+            if [ "$newest" = "$latest" ] && [ "$current" != "$latest" ]; then
+              echo "${repo}|${current}|${latest}|${file}|${next_lineno}" >> "$UPDATES_FILE"
+              echo "Update available: ${repo} ${current} -> ${latest} in ${file}:${next_lineno}"
+            else
+              echo "Up to date: ${repo} ${current} in ${file}:${next_lineno}"
+            fi
+          done < <(grep -rnP '# auto-update: source=github-releases repo=' "$SCAN_PATH" \
+            --include='*.yml' --include='*.yaml' 2>/dev/null)
+
+          if [ ! -s "$UPDATES_FILE" ]; then
+            echo "All annotated versions are up to date."
+            echo "has_updates=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_updates=true" >> "$GITHUB_OUTPUT"
+
+          # Apply updates using exact string matching.
+          # Both $current and $latest are validated as strict semver (v0.0.0) above,
+          # so the only special character is '.'. We escape it for correctness.
+          # The first-match-only replacement is intentional — the annotation contract
+          # requires the version to appear exactly once on the annotated line.
+          while IFS='|' read -r repo current latest file next_lineno; do
+            escaped_current=$(printf '%s' "$current" | sed 's/[.]/\\./g')
+            # $latest is validated semver — no sed-special chars on the replacement side
+            sed -i "${next_lineno}s/${escaped_current}/${latest}/" "$file"
+            echo "Updated ${file}:${next_lineno}: ${current} -> ${latest}"
+          done < "$UPDATES_FILE"
+
+          # Build PR summary. Uses a random heredoc delimiter to prevent
+          # injection into GITHUB_ENV. All values are sanitized:
+          #   - repo: validated against ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$
+          #   - versions: validated against strict semver ^v[0-9]+\.[0-9]+\.[0-9]+$
+          #   - file paths: backticks stripped to prevent markdown injection
+          delimiter="SUMMARY_$(openssl rand -hex 8)"
+          {
+            echo "SUMMARY<<${delimiter}"
+            prev_repo=""
+            while IFS='|' read -r repo current latest file next_lineno; do
+              safe_file="${file//\`/}"
+              if [ "$repo" != "$prev_repo" ]; then
+                echo "### [\`${repo}\`](https://github.com/${repo})"
+                echo "Release notes: https://github.com/${repo}/releases/tag/${latest}"
+                echo ""
+                prev_repo="$repo"
+              fi
+              echo "- \`${safe_file}:${next_lineno}\`: \`${current}\` -> \`${latest}\`"
+            done < "$UPDATES_FILE"
+            echo "${delimiter}"
+          } >> "$GITHUB_ENV"
+
+      - name: Create pull request
+        if: steps.scan.outputs.has_updates == 'true'
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          base: ${{ inputs.base-branch }}
+          labels: dependencies
+          committer: "${{ inputs.committer-name }} <${{ inputs.committer-email }}>"
+          commit-message: "🧹 Update pinned tool versions"
+          author: "${{ inputs.committer-name }} <${{ inputs.committer-email }}>"
+          title: "🧹 Update pinned tool versions"
+          branch: ${{ inputs.pr-branch }}
+          body: |
+            Automated update of pinned tool versions detected via `# auto-update:` annotations.
+
+            ${{ env.SUMMARY }}


### PR DESCRIPTION
## Summary
- Adds a reusable workflow that scans workflow files for `# auto-update:` annotations and opens a PR when newer versions are available
- Zero third-party dependencies beyond `gh` CLI and `peter-evans/create-pull-request`
- Lightweight alternative to Renovate for pinned version strings in workflow files

## Annotation format
Place directly above the version line in any workflow YAML:
```yaml
# auto-update: source=github-releases repo=goreleaser/goreleaser
version: v2.15.3
```

## Usage
```yaml
jobs:
  update-versions:
    uses: mondoohq/actions/.github/workflows/update-pinned-versions.yml@main
    permissions:
      contents: write
      pull-requests: write
    secrets:
      ssh-key: \${{ secrets.DEPLOY_KEY }}
```

## Configurable inputs
| Input | Default | Description |
|-------|---------|-------------|
| `scan-path` | `.github/` | Directory to scan |
| `base-branch` | `main` | Base branch for PRs |
| `pr-branch` | `version/pinned-tools-update` | PR branch name |
| `committer-name` | `github-actions[bot]` | Git committer |
| `committer-email` | bot noreply | Git committer email |

First consumer: mondoohq/mql (goreleaser version pinning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)