### PR TITLE
✨ Add reusable workflow for updating pinned tool versions

### DIFF
--- a/.github/scripts/update-pinned-versions.py
+++ b/.github/scripts/update-pinned-versions.py
@@ -33,6 +33,8 @@ Requirements:
     - Python 3.8+ (available on all GitHub Actions ubuntu runners)
 """
 
+from __future__ import annotations
+
 import os
 import re
 import subprocess
@@ -224,7 +226,13 @@ def scan_file(filepath: Path) -> list[Update]:
 
 
 def apply_updates(updates: list[Update]) -> None:
-    """Apply version updates to files."""
+    """Apply version updates to files.
+
+    Uses str.replace() for exact literal matching — no regex or sed involved,
+    so there are no escaping or delimiter concerns. The count=1 argument
+    ensures only the first occurrence on the line is replaced (matching the
+    annotation contract that the version appears exactly once).
+    """
     for u in updates:
         path = Path(u.file)
         lines = path.read_text().splitlines()

--- a/.github/scripts/update-pinned-versions.py
+++ b/.github/scripts/update-pinned-versions.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Scan workflow files for # auto-update annotations and propose version bumps.
+
+Annotation format (place directly above the version line):
+
+    # auto-update: source=github-releases repo=owner/repo
+    version: v1.2.3
+
+Optional range= constraint controls which updates are allowed:
+
+    range=major   — allow all updates (default)
+    range=minor   — allow minor and patch (v2.x.x but not v3.x.x)
+    range=patch   — allow patch only (v2.15.x but not v2.16.x)
+    range=minor+patch — same as minor (explicit alias)
+    range=major+minor — allow major and minor, skip patch-only bumps
+    range=major+patch — allow major and patch, skip minor-only bumps
+
+Examples:
+
+    # auto-update: source=github-releases repo=goreleaser/goreleaser range=minor
+    version: v2.15.3
+
+    # auto-update: source=github-releases repo=actions/checkout range=patch
+    version: v6.0.2
+
+Requirements:
+    - Versions must be strict semver (v0.0.0), no pre-release suffixes
+    - The version must appear exactly once on the line following the annotation
+    - Only github-releases (not raw tags) are supported as a source
+    - Python 3.8+ (available on all GitHub Actions ubuntu runners)
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+SEMVER_RE = re.compile(r"\bv(\d+)\.(\d+)\.(\d+)\b")
+ANNOTATION_RE = re.compile(r"#\s*auto-update:\s*(.*)")
+KV_RE = re.compile(r"(\w+)=(\S+)")
+
+VALID_RANGES = {"major", "minor", "patch", "minor+patch", "major+minor", "major+patch"}
+REPO_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
+
+
+@dataclass
+class SemVer:
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def parse(cls, s: str) -> "SemVer | None":
+        m = SEMVER_RE.search(s)
+        if not m:
+            return None
+        return cls(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+    def __str__(self) -> str:
+        return f"v{self.major}.{self.minor}.{self.patch}"
+
+    def __gt__(self, other: "SemVer") -> bool:
+        return (self.major, self.minor, self.patch) > (
+            other.major,
+            other.minor,
+            other.patch,
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SemVer):
+            return NotImplemented
+        return (self.major, self.minor, self.patch) == (
+            other.major,
+            other.minor,
+            other.patch,
+        )
+
+
+def bump_type(current: SemVer, latest: SemVer) -> str | None:
+    """Return 'major', 'minor', or 'patch' describing what changed, or None if equal."""
+    if latest.major != current.major:
+        return "major"
+    if latest.minor != current.minor:
+        return "minor"
+    if latest.patch != current.patch:
+        return "patch"
+    return None
+
+
+def is_allowed(current: SemVer, latest: SemVer, range_str: str) -> bool:
+    """Check if the update from current to latest is allowed by the range constraint."""
+    bt = bump_type(current, latest)
+    if bt is None:
+        return False
+    if range_str == "major":
+        return True
+    if range_str in ("minor", "minor+patch"):
+        return bt in ("minor", "patch")
+    if range_str == "patch":
+        return bt == "patch"
+    if range_str == "major+minor":
+        return bt in ("major", "minor")
+    if range_str == "major+patch":
+        return bt in ("major", "patch")
+    return True
+
+
+def warn(msg: str) -> None:
+    print(f"::warning::{msg}", flush=True)
+
+
+def gh_api(endpoint: str) -> str | None:
+    """Call gh api and return stdout, or None on error."""
+    result = subprocess.run(
+        ["gh", "api", endpoint, "--jq", ".tag_name"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+@dataclass
+class Update:
+    repo: str
+    current: SemVer
+    latest: SemVer
+    file: str
+    line_no: int
+    range_str: str
+
+
+@dataclass
+class ScanResult:
+    updates: list[Update] = field(default_factory=list)
+
+
+def parse_annotation(line: str) -> dict[str, str] | None:
+    """Parse a # auto-update: key=value key=value line into a dict."""
+    m = ANNOTATION_RE.search(line)
+    if not m:
+        return None
+    return dict(KV_RE.findall(m.group(1)))
+
+
+def scan_file(filepath: Path) -> list[Update]:
+    """Scan a single file for auto-update annotations."""
+    updates = []
+    lines = filepath.read_text().splitlines()
+
+    for i, line in enumerate(lines):
+        attrs = parse_annotation(line)
+        if attrs is None:
+            continue
+        if attrs.get("source") != "github-releases":
+            continue
+
+        repo = attrs.get("repo", "")
+        if not repo or not REPO_RE.match(repo):
+            warn(f"Invalid repo '{repo}' in annotation at {filepath}:{i + 1}")
+            continue
+
+        range_str = attrs.get("range", "major")
+        if range_str not in VALID_RANGES:
+            warn(
+                f"Invalid range '{range_str}' at {filepath}:{i + 1}, "
+                f"must be one of: {', '.join(sorted(VALID_RANGES))}"
+            )
+            continue
+
+        # Version is on the next line
+        version_line_no = i + 1
+        if version_line_no >= len(lines):
+            warn(f"Annotation at {filepath}:{i + 1} has no following line")
+            continue
+
+        version_line = lines[version_line_no]
+        m = SEMVER_RE.search(version_line)
+        if not m:
+            warn(
+                f"No semver found on line {version_line_no + 1} of {filepath} "
+                f"(annotation for {repo})"
+            )
+            continue
+        current = SemVer(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+        # Fetch latest release
+        tag = gh_api(f"repos/{repo}/releases/latest")
+        if not tag:
+            warn(f"Failed to fetch latest release for {repo}")
+            continue
+
+        latest = SemVer.parse(tag)
+        if not latest:
+            warn(f"Latest tag '{tag}' for {repo} is not strict semver")
+            continue
+
+        if not latest > current:
+            print(f"Up to date: {repo} {current} in {filepath}:{version_line_no + 1}")
+            continue
+
+        if not is_allowed(current, latest, range_str):
+            bt = bump_type(current, latest)
+            print(
+                f"Skipped: {repo} {current} -> {latest} ({bt} bump blocked by range={range_str}) "
+                f"in {filepath}:{version_line_no + 1}"
+            )
+            continue
+
+        print(
+            f"Update available: {repo} {current} -> {latest} "
+            f"in {filepath}:{version_line_no + 1}"
+        )
+        updates.append(
+            Update(
+                repo=repo,
+                current=current,
+                latest=latest,
+                file=str(filepath),
+                line_no=version_line_no + 1,  # 1-indexed
+                range_str=range_str,
+            )
+        )
+
+    return updates
+
+
+def apply_updates(updates: list[Update]) -> None:
+    """Apply version updates to files."""
+    for u in updates:
+        path = Path(u.file)
+        lines = path.read_text().splitlines()
+        line_idx = u.line_no - 1  # 0-indexed
+        old_line = lines[line_idx]
+        new_line = old_line.replace(str(u.current), str(u.latest), 1)
+        if old_line == new_line:
+            warn(f"Failed to replace {u.current} on line {u.line_no} of {u.file}")
+            continue
+        lines[line_idx] = new_line
+        path.write_text("\n".join(lines) + "\n")
+        print(f"Updated {u.file}:{u.line_no}: {u.current} -> {u.latest}")
+
+
+def build_summary(updates: list[Update]) -> str:
+    """Build a markdown summary grouped by repo."""
+    lines = []
+    prev_repo = ""
+    for u in updates:
+        if u.repo != prev_repo:
+            safe_repo = u.repo.replace("`", "")
+            lines.append(f"### [`{safe_repo}`](https://github.com/{safe_repo})")
+            lines.append(
+                f"Release notes: https://github.com/{safe_repo}/releases/tag/{u.latest}"
+            )
+            lines.append("")
+            prev_repo = u.repo
+        safe_file = u.file.replace("`", "")
+        range_info = f" (range={u.range_str})" if u.range_str != "major" else ""
+        lines.append(
+            f"- `{safe_file}:{u.line_no}`: `{u.current}` -> `{u.latest}`{range_info}"
+        )
+    return "\n".join(lines)
+
+
+def set_output(name: str, value: str) -> None:
+    """Set a GitHub Actions output variable."""
+    output_file = os.environ.get("GITHUB_OUTPUT", "")
+    if output_file:
+        with open(output_file, "a") as f:
+            f.write(f"{name}={value}\n")
+
+
+def set_env(name: str, value: str) -> None:
+    """Set a GitHub Actions environment variable (multiline-safe)."""
+    env_file = os.environ.get("GITHUB_ENV", "")
+    if env_file:
+        # Use a random delimiter to prevent injection
+        delimiter = f"ghadelim_{os.urandom(8).hex()}"
+        with open(env_file, "a") as f:
+            f.write(f"{name}<<{delimiter}\n{value}\n{delimiter}\n")
+
+
+def main() -> None:
+    scan_path = os.environ.get("SCAN_PATH", ".github/")
+    root = Path(scan_path)
+
+    if not root.exists():
+        warn(f"Scan path '{scan_path}' does not exist")
+        set_output("has_updates", "false")
+        sys.exit(0)
+
+    # Find all yaml files
+    files = sorted(set(root.rglob("*.yml")) | set(root.rglob("*.yaml")))
+
+    all_updates: list[Update] = []
+    for filepath in files:
+        all_updates.extend(scan_file(filepath))
+
+    if not all_updates:
+        print("All annotated versions are up to date.")
+        set_output("has_updates", "false")
+        sys.exit(0)
+
+    set_output("has_updates", "true")
+    apply_updates(all_updates)
+
+    summary = build_summary(all_updates)
+    set_env("SUMMARY", summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/update-pinned-versions.py
+++ b/.github/scripts/update-pinned-versions.py
@@ -6,26 +6,20 @@ Annotation format (place directly above the version line):
     # auto-update: source=github-releases repo=owner/repo
     version: v1.2.3
 
-Optional ignore= constraint (aligned with Dependabot's update-types syntax)
-controls which semver bumps to skip:
+Optional updates= constraint controls which semver bumps are allowed:
 
-    ignore=major         — skip major bumps (allow minor + patch)
-    ignore=minor         — skip minor bumps (allow major + patch)
-    ignore=patch         — skip patch bumps (allow major + minor)
-    ignore=major,minor   — skip major and minor (allow patch only)
-    ignore=major,patch   — skip major and patch (allow minor only)
-    ignore=minor,patch   — skip minor and patch (allow major only)
-
-When omitted, all update types are allowed (equivalent to Dependabot's default).
+    updates=all     — allow all updates (default)
+    updates=minor   — allow minor and patch only (skip major)
+    updates=patch   — allow patch only (skip major and minor)
 
 Examples:
 
-    # Only allow minor and patch updates (skip major):
-    # auto-update: source=github-releases repo=goreleaser/goreleaser ignore=major
+    # Only allow minor and patch updates:
+    # auto-update: source=github-releases repo=goreleaser/goreleaser updates=minor
     version: v2.15.3
 
     # Only allow patch updates:
-    # auto-update: source=github-releases repo=actions/checkout ignore=major,minor
+    # auto-update: source=github-releases repo=actions/checkout updates=patch
     version: v6.0.2
 
     # Allow all updates (default):
@@ -43,14 +37,14 @@ import os
 import re
 import subprocess
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 SEMVER_RE = re.compile(r"\bv(\d+)\.(\d+)\.(\d+)\b")
 ANNOTATION_RE = re.compile(r"#\s*auto-update:\s*(.*)")
 KV_RE = re.compile(r"(\w+)=(\S+)")
 
-BUMP_TYPES = {"major", "minor", "patch"}
+VALID_UPDATES = {"all", "minor", "patch"}
 REPO_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
 
 
@@ -98,30 +92,18 @@ def bump_type(current: SemVer, latest: SemVer) -> str | None:
     return None
 
 
-def parse_ignore(ignore_str: str) -> set[str]:
-    """Parse a comma-separated ignore string into a set of bump types.
-
-    Returns an empty set if ignore_str is empty (allow all).
-    Raises ValueError if any token is not a valid bump type.
-    """
-    if not ignore_str:
-        return set()
-    types = {t.strip() for t in ignore_str.split(",")}
-    invalid = types - BUMP_TYPES
-    if invalid:
-        raise ValueError(
-            f"invalid ignore types: {', '.join(sorted(invalid))}; "
-            f"must be a comma-separated list of: {', '.join(sorted(BUMP_TYPES))}"
-        )
-    return types
-
-
-def is_allowed(current: SemVer, latest: SemVer, ignored: set[str]) -> bool:
-    """Check if the update from current to latest is allowed given ignored bump types."""
+def is_allowed(current: SemVer, latest: SemVer, updates: str) -> bool:
+    """Check if the update from current to latest is allowed by the updates constraint."""
     bt = bump_type(current, latest)
     if bt is None:
         return False
-    return bt not in ignored
+    if updates == "all":
+        return True
+    if updates == "minor":
+        return bt in ("minor", "patch")
+    if updates == "patch":
+        return bt == "patch"
+    return True
 
 
 def warn(msg: str) -> None:
@@ -147,14 +129,7 @@ class Update:
     latest: SemVer
     file: str
     line_no: int
-    ignored: set[str]
-
-    @property
-    def ignore_label(self) -> str:
-        """Human-readable label for the ignore constraint."""
-        if not self.ignored:
-            return ""
-        return f"ignore={','.join(sorted(self.ignored))}"
+    updates: str
 
 
 def parse_annotation(line: str) -> dict[str, str] | None:
@@ -182,12 +157,12 @@ def scan_file(filepath: Path) -> list[Update]:
             warn(f"Invalid repo '{repo}' in annotation at {filepath}:{i + 1}")
             continue
 
-        # Parse ignore constraint
-        ignore_str = attrs.get("ignore", "")
-        try:
-            ignored = parse_ignore(ignore_str)
-        except ValueError as e:
-            warn(f"{e} at {filepath}:{i + 1}")
+        updates_str = attrs.get("updates", "all")
+        if updates_str not in VALID_UPDATES:
+            warn(
+                f"Invalid updates='{updates_str}' at {filepath}:{i + 1}, "
+                f"must be one of: {', '.join(sorted(VALID_UPDATES))}"
+            )
             continue
 
         # Version is on the next line
@@ -221,11 +196,11 @@ def scan_file(filepath: Path) -> list[Update]:
             print(f"Up to date: {repo} {current} in {filepath}:{version_line_no + 1}")
             continue
 
-        if not is_allowed(current, latest, ignored):
+        if not is_allowed(current, latest, updates_str):
             bt = bump_type(current, latest)
             print(
                 f"Skipped: {repo} {current} -> {latest} "
-                f"({bt} bump blocked by ignore={','.join(sorted(ignored))}) "
+                f"({bt} bump blocked by updates={updates_str}) "
                 f"in {filepath}:{version_line_no + 1}"
             )
             continue
@@ -241,7 +216,7 @@ def scan_file(filepath: Path) -> list[Update]:
                 latest=latest,
                 file=str(filepath),
                 line_no=version_line_no + 1,  # 1-indexed
-                ignored=ignored,
+                updates=updates_str,
             )
         )
 
@@ -278,7 +253,7 @@ def build_summary(updates: list[Update]) -> str:
             lines.append("")
             prev_repo = u.repo
         safe_file = u.file.replace("`", "")
-        constraint = f" ({u.ignore_label})" if u.ignore_label else ""
+        constraint = f" (updates={u.updates})" if u.updates != "all" else ""
         lines.append(
             f"- `{safe_file}:{u.line_no}`: `{u.current}` -> `{u.latest}`{constraint}"
         )

--- a/.github/scripts/update-pinned-versions.py
+++ b/.github/scripts/update-pinned-versions.py
@@ -6,22 +6,31 @@ Annotation format (place directly above the version line):
     # auto-update: source=github-releases repo=owner/repo
     version: v1.2.3
 
-Optional range= constraint controls which updates are allowed:
+Optional ignore= constraint (aligned with Dependabot's update-types syntax)
+controls which semver bumps to skip:
 
-    range=major   — allow all updates (default)
-    range=minor   — allow minor and patch (v2.x.x but not v3.x.x)
-    range=patch   — allow patch only (v2.15.x but not v2.16.x)
-    range=minor+patch — same as minor (explicit alias)
-    range=major+minor — allow major and minor, skip patch-only bumps
-    range=major+patch — allow major and patch, skip minor-only bumps
+    ignore=major         — skip major bumps (allow minor + patch)
+    ignore=minor         — skip minor bumps (allow major + patch)
+    ignore=patch         — skip patch bumps (allow major + minor)
+    ignore=major,minor   — skip major and minor (allow patch only)
+    ignore=major,patch   — skip major and patch (allow minor only)
+    ignore=minor,patch   — skip minor and patch (allow major only)
+
+When omitted, all update types are allowed (equivalent to Dependabot's default).
 
 Examples:
 
-    # auto-update: source=github-releases repo=goreleaser/goreleaser range=minor
+    # Only allow minor and patch updates (skip major):
+    # auto-update: source=github-releases repo=goreleaser/goreleaser ignore=major
     version: v2.15.3
 
-    # auto-update: source=github-releases repo=actions/checkout range=patch
+    # Only allow patch updates:
+    # auto-update: source=github-releases repo=actions/checkout ignore=major,minor
     version: v6.0.2
+
+    # Allow all updates (default):
+    # auto-update: source=github-releases repo=hashicorp/terraform
+    version: v1.9.0
 
 Requirements:
     - Versions must be strict semver (v0.0.0), no pre-release suffixes
@@ -30,7 +39,6 @@ Requirements:
     - Python 3.8+ (available on all GitHub Actions ubuntu runners)
 """
 
-import json
 import os
 import re
 import subprocess
@@ -42,7 +50,7 @@ SEMVER_RE = re.compile(r"\bv(\d+)\.(\d+)\.(\d+)\b")
 ANNOTATION_RE = re.compile(r"#\s*auto-update:\s*(.*)")
 KV_RE = re.compile(r"(\w+)=(\S+)")
 
-VALID_RANGES = {"major", "minor", "patch", "minor+patch", "major+minor", "major+patch"}
+BUMP_TYPES = {"major", "minor", "patch"}
 REPO_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
 
 
@@ -90,22 +98,30 @@ def bump_type(current: SemVer, latest: SemVer) -> str | None:
     return None
 
 
-def is_allowed(current: SemVer, latest: SemVer, range_str: str) -> bool:
-    """Check if the update from current to latest is allowed by the range constraint."""
+def parse_ignore(ignore_str: str) -> set[str]:
+    """Parse a comma-separated ignore string into a set of bump types.
+
+    Returns an empty set if ignore_str is empty (allow all).
+    Raises ValueError if any token is not a valid bump type.
+    """
+    if not ignore_str:
+        return set()
+    types = {t.strip() for t in ignore_str.split(",")}
+    invalid = types - BUMP_TYPES
+    if invalid:
+        raise ValueError(
+            f"invalid ignore types: {', '.join(sorted(invalid))}; "
+            f"must be a comma-separated list of: {', '.join(sorted(BUMP_TYPES))}"
+        )
+    return types
+
+
+def is_allowed(current: SemVer, latest: SemVer, ignored: set[str]) -> bool:
+    """Check if the update from current to latest is allowed given ignored bump types."""
     bt = bump_type(current, latest)
     if bt is None:
         return False
-    if range_str == "major":
-        return True
-    if range_str in ("minor", "minor+patch"):
-        return bt in ("minor", "patch")
-    if range_str == "patch":
-        return bt == "patch"
-    if range_str == "major+minor":
-        return bt in ("major", "minor")
-    if range_str == "major+patch":
-        return bt in ("major", "patch")
-    return True
+    return bt not in ignored
 
 
 def warn(msg: str) -> None:
@@ -131,12 +147,14 @@ class Update:
     latest: SemVer
     file: str
     line_no: int
-    range_str: str
+    ignored: set[str]
 
-
-@dataclass
-class ScanResult:
-    updates: list[Update] = field(default_factory=list)
+    @property
+    def ignore_label(self) -> str:
+        """Human-readable label for the ignore constraint."""
+        if not self.ignored:
+            return ""
+        return f"ignore={','.join(sorted(self.ignored))}"
 
 
 def parse_annotation(line: str) -> dict[str, str] | None:
@@ -164,12 +182,12 @@ def scan_file(filepath: Path) -> list[Update]:
             warn(f"Invalid repo '{repo}' in annotation at {filepath}:{i + 1}")
             continue
 
-        range_str = attrs.get("range", "major")
-        if range_str not in VALID_RANGES:
-            warn(
-                f"Invalid range '{range_str}' at {filepath}:{i + 1}, "
-                f"must be one of: {', '.join(sorted(VALID_RANGES))}"
-            )
+        # Parse ignore constraint
+        ignore_str = attrs.get("ignore", "")
+        try:
+            ignored = parse_ignore(ignore_str)
+        except ValueError as e:
+            warn(f"{e} at {filepath}:{i + 1}")
             continue
 
         # Version is on the next line
@@ -203,10 +221,11 @@ def scan_file(filepath: Path) -> list[Update]:
             print(f"Up to date: {repo} {current} in {filepath}:{version_line_no + 1}")
             continue
 
-        if not is_allowed(current, latest, range_str):
+        if not is_allowed(current, latest, ignored):
             bt = bump_type(current, latest)
             print(
-                f"Skipped: {repo} {current} -> {latest} ({bt} bump blocked by range={range_str}) "
+                f"Skipped: {repo} {current} -> {latest} "
+                f"({bt} bump blocked by ignore={','.join(sorted(ignored))}) "
                 f"in {filepath}:{version_line_no + 1}"
             )
             continue
@@ -222,7 +241,7 @@ def scan_file(filepath: Path) -> list[Update]:
                 latest=latest,
                 file=str(filepath),
                 line_no=version_line_no + 1,  # 1-indexed
-                range_str=range_str,
+                ignored=ignored,
             )
         )
 
@@ -259,9 +278,9 @@ def build_summary(updates: list[Update]) -> str:
             lines.append("")
             prev_repo = u.repo
         safe_file = u.file.replace("`", "")
-        range_info = f" (range={u.range_str})" if u.range_str != "major" else ""
+        constraint = f" ({u.ignore_label})" if u.ignore_label else ""
         lines.append(
-            f"- `{safe_file}:{u.line_no}`: `{u.current}` -> `{u.latest}`{range_info}"
+            f"- `{safe_file}:{u.line_no}`: `{u.current}` -> `{u.latest}`{constraint}"
         )
     return "\n".join(lines)
 
@@ -278,7 +297,6 @@ def set_env(name: str, value: str) -> None:
     """Set a GitHub Actions environment variable (multiline-safe)."""
     env_file = os.environ.get("GITHUB_ENV", "")
     if env_file:
-        # Use a random delimiter to prevent injection
         delimiter = f"ghadelim_{os.urandom(8).hex()}"
         with open(env_file, "a") as f:
             f.write(f"{name}<<{delimiter}\n{value}\n{delimiter}\n")
@@ -293,7 +311,6 @@ def main() -> None:
         set_output("has_updates", "false")
         sys.exit(0)
 
-    # Find all yaml files
     files = sorted(set(root.rglob("*.yml")) | set(root.rglob("*.yaml")))
 
     all_updates: list[Update] = []

--- a/.github/workflows/update-pinned-versions.yml
+++ b/.github/workflows/update-pinned-versions.yml
@@ -111,10 +111,9 @@ jobs:
 
             next_lineno=$((lineno + 1))
             version_line=$(sed -n "${next_lineno}p" "$file")
-            # Extract the version value from the line. Uses tail -1 to grab the
-            # last semver match, skipping any versions in comments or hashes that
-            # may appear earlier on the line (e.g., "version: v2.0.0 # was v1.9.0").
-            current=$(echo "$version_line" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
+            # Extract the first semver on the line — this is the actual value
+            # (e.g., "version: v2.0.0 # was v1.9.0" extracts v2.0.0).
+            current=$(echo "$version_line" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
 
             if [ -z "$current" ]; then
               echo "::warning::No version found on line ${next_lineno} of ${file} (annotation for ${repo})"

--- a/.github/workflows/update-pinned-versions.yml
+++ b/.github/workflows/update-pinned-versions.yml
@@ -7,8 +7,23 @@
 #   # auto-update: source=github-releases repo=owner/repo
 #   version: v1.2.3
 #
+# Optional range= constraint controls which updates are allowed:
+#   range=major       — allow all updates (default)
+#   range=minor       — allow minor and patch only
+#   range=patch       — allow patch only
+#   range=minor+patch — same as minor
+#   range=major+minor — skip patch-only bumps
+#   range=major+patch — skip minor-only bumps
+#
+# Examples:
+#   # auto-update: source=github-releases repo=goreleaser/goreleaser range=minor
+#   version: v2.15.3
+#
+#   # auto-update: source=github-releases repo=actions/checkout range=patch
+#   version: v6.0.2
+#
 # Requirements:
-#   - The version must be strict semver (v0.0.0), no pre-release suffixes
+#   - Versions must be strict semver (v0.0.0), no pre-release suffixes
 #   - The version must appear exactly once on the line following the annotation
 #   - Only github-releases (not raw tags) are supported as a source
 #
@@ -80,122 +95,26 @@ jobs:
         with:
           ssh-key: ${{ secrets.ssh-key || '' }}
 
+      # Fetch the script from this repo (mondoohq/actions), not from the caller repo.
+      # This ensures the script version matches the workflow version.
+      - name: Fetch update script
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: mondoohq/actions
+          path: _actions
+          sparse-checkout: .github/scripts/update-pinned-versions.py
+          sparse-checkout-cone-mode: false
+
       - name: Scan for annotated versions and update
         id: scan
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SCAN_PATH: ${{ inputs.scan-path }}
-        run: |
-          set -euo pipefail
+        run: python3 _actions/.github/scripts/update-pinned-versions.py
 
-          # Strict semver pattern used for both current and latest validation
-          SEMVER_RE='^v[0-9]+\.[0-9]+\.[0-9]+$'
-
-          # Temp file for collecting updates across iterations. Cleaned up on
-          # exit via trap. All reads (apply + summary) happen in this same run:
-          # block before the shell exits, so the file is always available.
-          UPDATES_FILE=$(mktemp)
-          trap 'rm -f "$UPDATES_FILE"' EXIT
-
-          # Find all auto-update annotations.
-          # Use process substitution to keep the loop in the current shell,
-          # so writes to UPDATES_FILE are visible after the loop.
-          # Note: grep -oP (PCRE) is required. This is safe because the workflow
-          # is pinned to ubuntu-latest, which always ships GNU grep with PCRE.
-          while IFS=: read -r file lineno _; do
-            annotation=$(sed -n "${lineno}p" "$file")
-            repo=$(echo "$annotation" | grep -oP '# auto-update: source=github-releases repo=\K\S+')
-
-            if [ -z "$repo" ] || ! [[ "$repo" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
-              echo "::warning::Invalid or malformed annotation on line ${lineno} of ${file}: repo=${repo}"
-              continue
-            fi
-
-            next_lineno=$((lineno + 1))
-            version_line=$(sed -n "${next_lineno}p" "$file")
-            # Extract the first strict semver on the line — this is the actual value
-            # (e.g., "version: v2.0.0 # was v1.9.0" extracts v2.0.0).
-            # Word boundaries (\b) prevent partial matches inside pre-release tags
-            # like v1.2.3-rc1 (which would otherwise extract v1.2.3).
-            current=$(echo "$version_line" | grep -oP '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | head -1)
-
-            if [ -z "$current" ]; then
-              echo "::warning::No version found on line ${next_lineno} of ${file} (annotation for ${repo})"
-              continue
-            fi
-            if ! [[ "$current" =~ $SEMVER_RE ]]; then
-              echo "::warning::Current version '${current}' on line ${next_lineno} of ${file} is not strict semver, skipping"
-              continue
-            fi
-
-            # Fetch latest release. Separate HTTP/auth errors from empty responses.
-            api_output=$(gh api "repos/${repo}/releases/latest" --jq '.tag_name' 2>&1) || {
-              echo "::warning::API error fetching latest release for ${repo}: ${api_output}"
-              continue
-            }
-            latest="$api_output"
-            if [ -z "$latest" ]; then
-              echo "::warning::No release found for ${repo} (repo may only use tags, not releases)"
-              continue
-            fi
-            if ! [[ "$latest" =~ $SEMVER_RE ]]; then
-              echo "::warning::Latest version '${latest}' for ${repo} is not strict semver, skipping"
-              continue
-            fi
-
-            # Only update if latest is actually newer (avoids downgrade PRs on rollbacks)
-            newest=$(printf '%s\n%s' "$current" "$latest" | sort -V | tail -1)
-            if [ "$newest" = "$latest" ] && [ "$current" != "$latest" ]; then
-              echo "${repo}|${current}|${latest}|${file}|${next_lineno}" >> "$UPDATES_FILE"
-              echo "Update available: ${repo} ${current} -> ${latest} in ${file}:${next_lineno}"
-            else
-              echo "Up to date: ${repo} ${current} in ${file}:${next_lineno}"
-            fi
-          done < <(grep -rnP '# auto-update: source=github-releases repo=' "$SCAN_PATH" \
-            --include='*.yml' --include='*.yaml' 2>/dev/null)
-
-          if [ ! -s "$UPDATES_FILE" ]; then
-            echo "All annotated versions are up to date."
-            echo "has_updates=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "has_updates=true" >> "$GITHUB_OUTPUT"
-
-          # Apply updates using exact string matching.
-          # Both $current and $latest are validated as strict semver (v0.0.0) above,
-          # so the only special character is '.'. We escape dots in the pattern side.
-          # $latest needs no escaping — sed replacement side treats '.' as literal,
-          # and semver can't contain '&', '/', or '\' (the only special replacement chars).
-          # The first-match-only replacement is intentional — the annotation contract
-          # requires the version to appear exactly once on the annotated line.
-          while IFS='|' read -r repo current latest file next_lineno; do
-            escaped_current=$(printf '%s' "$current" | sed 's/[.]/\\./g')
-            sed -i "${next_lineno}s/${escaped_current}/${latest}/" "$file"
-            echo "Updated ${file}:${next_lineno}: ${current} -> ${latest}"
-          done < "$UPDATES_FILE"
-
-          # Build PR summary. Uses a random heredoc delimiter to prevent
-          # injection into GITHUB_ENV. All values are sanitized:
-          #   - repo: validated against ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$
-          #   - versions: validated against strict semver ^v[0-9]+\.[0-9]+\.[0-9]+$
-          #   - file paths: backticks stripped to prevent markdown injection
-          delimiter="SUMMARY_$(openssl rand -hex 8)"
-          {
-            echo "SUMMARY<<${delimiter}"
-            prev_repo=""
-            while IFS='|' read -r repo current latest file next_lineno; do
-              safe_file="${file//\`/}"
-              if [ "$repo" != "$prev_repo" ]; then
-                echo "### [\`${repo}\`](https://github.com/${repo})"
-                echo "Release notes: https://github.com/${repo}/releases/tag/${latest}"
-                echo ""
-                prev_repo="$repo"
-              fi
-              echo "- \`${safe_file}:${next_lineno}\`: \`${current}\` -> \`${latest}\`"
-            done < "$UPDATES_FILE"
-            echo "${delimiter}"
-          } >> "$GITHUB_ENV"
+      - name: Clean up action checkout
+        if: always()
+        run: rm -rf _actions
 
       - name: Create pull request
         if: steps.scan.outputs.has_updates == 'true'

--- a/.github/workflows/update-pinned-versions.yml
+++ b/.github/workflows/update-pinned-versions.yml
@@ -7,23 +7,16 @@
 #   # auto-update: source=github-releases repo=owner/repo
 #   version: v1.2.3
 #
-# Optional ignore= constraint (Dependabot-style) controls which semver
-# bump types to skip. Comma-separated list of: major, minor, patch.
-#
-#   ignore=major       — skip major (allow minor + patch)
-#   ignore=minor       — skip minor (allow major + patch)
-#   ignore=patch       — skip patch (allow major + minor)
-#   ignore=major,minor — allow patch only
-#   ignore=major,patch — allow minor only
-#   ignore=minor,patch — allow major only
-#
-# When omitted, all update types are allowed (Dependabot default).
+# Optional updates= constraint controls which semver bumps are allowed:
+#   updates=all     — allow all updates (default)
+#   updates=minor   — allow minor and patch only (skip major)
+#   updates=patch   — allow patch only (skip major and minor)
 #
 # Examples:
-#   # auto-update: source=github-releases repo=goreleaser/goreleaser ignore=major
+#   # auto-update: source=github-releases repo=goreleaser/goreleaser updates=minor
 #   version: v2.15.3
 #
-#   # auto-update: source=github-releases repo=actions/checkout ignore=major,minor
+#   # auto-update: source=github-releases repo=actions/checkout updates=patch
 #   version: v6.0.2
 #
 # Requirements:

--- a/.github/workflows/update-pinned-versions.yml
+++ b/.github/workflows/update-pinned-versions.yml
@@ -7,19 +7,23 @@
 #   # auto-update: source=github-releases repo=owner/repo
 #   version: v1.2.3
 #
-# Optional range= constraint controls which updates are allowed:
-#   range=major       — allow all updates (default)
-#   range=minor       — allow minor and patch only
-#   range=patch       — allow patch only
-#   range=minor+patch — same as minor
-#   range=major+minor — skip patch-only bumps
-#   range=major+patch — skip minor-only bumps
+# Optional ignore= constraint (Dependabot-style) controls which semver
+# bump types to skip. Comma-separated list of: major, minor, patch.
+#
+#   ignore=major       — skip major (allow minor + patch)
+#   ignore=minor       — skip minor (allow major + patch)
+#   ignore=patch       — skip patch (allow major + minor)
+#   ignore=major,minor — allow patch only
+#   ignore=major,patch — allow minor only
+#   ignore=minor,patch — allow major only
+#
+# When omitted, all update types are allowed (Dependabot default).
 #
 # Examples:
-#   # auto-update: source=github-releases repo=goreleaser/goreleaser range=minor
+#   # auto-update: source=github-releases repo=goreleaser/goreleaser ignore=major
 #   version: v2.15.3
 #
-#   # auto-update: source=github-releases repo=actions/checkout range=patch
+#   # auto-update: source=github-releases repo=actions/checkout ignore=major,minor
 #   version: v6.0.2
 #
 # Requirements:

--- a/.github/workflows/update-pinned-versions.yml
+++ b/.github/workflows/update-pinned-versions.yml
@@ -1,0 +1,210 @@
+# Reusable workflow: Update pinned tool versions
+#
+# Scans workflow files for `# auto-update:` annotations and opens a PR
+# when newer versions are available.
+#
+# Annotation format (place directly above the version line):
+#   # auto-update: source=github-releases repo=owner/repo
+#   version: v1.2.3
+#
+# Requirements:
+#   - The version must be strict semver (v0.0.0), no pre-release suffixes
+#   - The version must appear exactly once on the line following the annotation
+#   - Only github-releases (not raw tags) are supported as a source
+#
+# Usage in a caller workflow:
+#   jobs:
+#     update-versions:
+#       uses: mondoohq/actions/.github/workflows/update-pinned-versions.yml@main
+#       permissions:
+#         contents: write
+#         pull-requests: write
+#       secrets:
+#         ssh-key: ${{ secrets.DEPLOY_KEY }}
+#
+# Or without an SSH deploy key (uses GITHUB_TOKEN, PRs won't trigger other workflows):
+#   jobs:
+#     update-versions:
+#       uses: mondoohq/actions/.github/workflows/update-pinned-versions.yml@main
+#       permissions:
+#         contents: write
+#         pull-requests: write
+
+name: Update pinned tool versions
+
+on:
+  workflow_call:
+    inputs:
+      scan-path:
+        description: "Directory to scan for annotations (default: .github/)"
+        required: false
+        default: ".github/"
+        type: string
+      base-branch:
+        description: "Base branch for the PR"
+        required: false
+        default: "main"
+        type: string
+      pr-branch:
+        description: "Branch name for the PR"
+        required: false
+        default: "version/pinned-tools-update"
+        type: string
+      committer-name:
+        description: "Git committer name"
+        required: false
+        default: "github-actions[bot]"
+        type: string
+      committer-email:
+        description: "Git committer email"
+        required: false
+        default: "41898282+github-actions[bot]@users.noreply.github.com"
+        type: string
+    secrets:
+      ssh-key:
+        description: "SSH deploy key for pushing (optional, falls back to GITHUB_TOKEN)"
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  update-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ssh-key: ${{ secrets.ssh-key || '' }}
+
+      - name: Scan for annotated versions and update
+        id: scan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SCAN_PATH: ${{ inputs.scan-path }}
+        run: |
+          set -euo pipefail
+
+          # Strict semver pattern used for both current and latest validation
+          SEMVER_RE='^v[0-9]+\.[0-9]+\.[0-9]+$'
+
+          # Temp file for collecting updates across iterations. Cleaned up on
+          # exit via trap. All reads (apply + summary) happen in this same run:
+          # block before the shell exits, so the file is always available.
+          UPDATES_FILE=$(mktemp)
+          trap 'rm -f "$UPDATES_FILE"' EXIT
+
+          # Find all auto-update annotations.
+          # Use process substitution to keep the loop in the current shell,
+          # so writes to UPDATES_FILE are visible after the loop.
+          while IFS=: read -r file lineno _; do
+            annotation=$(sed -n "${lineno}p" "$file")
+            repo=$(echo "$annotation" | grep -oP '# auto-update: source=github-releases repo=\K\S+')
+
+            if [ -z "$repo" ] || ! [[ "$repo" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+              echo "::warning::Invalid or malformed annotation on line ${lineno} of ${file}: repo=${repo}"
+              continue
+            fi
+
+            next_lineno=$((lineno + 1))
+            version_line=$(sed -n "${next_lineno}p" "$file")
+            # Extract the version value from the line. Uses tail -1 to grab the
+            # last semver match, skipping any versions in comments or hashes that
+            # may appear earlier on the line (e.g., "version: v2.0.0 # was v1.9.0").
+            current=$(echo "$version_line" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
+
+            if [ -z "$current" ]; then
+              echo "::warning::No version found on line ${next_lineno} of ${file} (annotation for ${repo})"
+              continue
+            fi
+            if ! [[ "$current" =~ $SEMVER_RE ]]; then
+              echo "::warning::Current version '${current}' on line ${next_lineno} of ${file} is not strict semver, skipping"
+              continue
+            fi
+
+            # Fetch latest release. Separate HTTP/auth errors from empty responses.
+            api_output=$(gh api "repos/${repo}/releases/latest" --jq '.tag_name' 2>&1) || {
+              echo "::warning::API error fetching latest release for ${repo}: ${api_output}"
+              continue
+            }
+            latest="$api_output"
+            if [ -z "$latest" ]; then
+              echo "::warning::No release found for ${repo} (repo may only use tags, not releases)"
+              continue
+            fi
+            if ! [[ "$latest" =~ $SEMVER_RE ]]; then
+              echo "::warning::Latest version '${latest}' for ${repo} is not strict semver, skipping"
+              continue
+            fi
+
+            # Only update if latest is actually newer (avoids downgrade PRs on rollbacks)
+            newest=$(printf '%s\n%s' "$current" "$latest" | sort -V | tail -1)
+            if [ "$newest" = "$latest" ] && [ "$current" != "$latest" ]; then
+              echo "${repo}|${current}|${latest}|${file}|${next_lineno}" >> "$UPDATES_FILE"
+              echo "Update available: ${repo} ${current} -> ${latest} in ${file}:${next_lineno}"
+            else
+              echo "Up to date: ${repo} ${current} in ${file}:${next_lineno}"
+            fi
+          done < <(grep -rnP '# auto-update: source=github-releases repo=' "$SCAN_PATH" \
+            --include='*.yml' --include='*.yaml' 2>/dev/null)
+
+          if [ ! -s "$UPDATES_FILE" ]; then
+            echo "All annotated versions are up to date."
+            echo "has_updates=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_updates=true" >> "$GITHUB_OUTPUT"
+
+          # Apply updates using exact string matching.
+          # Both $current and $latest are validated as strict semver (v0.0.0) above,
+          # so the only special character is '.'. We escape it for correctness.
+          # The first-match-only replacement is intentional — the annotation contract
+          # requires the version to appear exactly once on the annotated line.
+          while IFS='|' read -r repo current latest file next_lineno; do
+            escaped_current=$(printf '%s' "$current" | sed 's/[.]/\\./g')
+            # $latest is validated semver — no sed-special chars on the replacement side
+            sed -i "${next_lineno}s/${escaped_current}/${latest}/" "$file"
+            echo "Updated ${file}:${next_lineno}: ${current} -> ${latest}"
+          done < "$UPDATES_FILE"
+
+          # Build PR summary. Uses a random heredoc delimiter to prevent
+          # injection into GITHUB_ENV. All values are sanitized:
+          #   - repo: validated against ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$
+          #   - versions: validated against strict semver ^v[0-9]+\.[0-9]+\.[0-9]+$
+          #   - file paths: backticks stripped to prevent markdown injection
+          delimiter="SUMMARY_$(openssl rand -hex 8)"
+          {
+            echo "SUMMARY<<${delimiter}"
+            prev_repo=""
+            while IFS='|' read -r repo current latest file next_lineno; do
+              safe_file="${file//\`/}"
+              if [ "$repo" != "$prev_repo" ]; then
+                echo "### [\`${repo}\`](https://github.com/${repo})"
+                echo "Release notes: https://github.com/${repo}/releases/tag/${latest}"
+                echo ""
+                prev_repo="$repo"
+              fi
+              echo "- \`${safe_file}:${next_lineno}\`: \`${current}\` -> \`${latest}\`"
+            done < "$UPDATES_FILE"
+            echo "${delimiter}"
+          } >> "$GITHUB_ENV"
+
+      - name: Create pull request
+        if: steps.scan.outputs.has_updates == 'true'
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          base: ${{ inputs.base-branch }}
+          labels: dependencies
+          committer: "${{ inputs.committer-name }} <${{ inputs.committer-email }}>"
+          commit-message: "🧹 Update pinned tool versions"
+          author: "${{ inputs.committer-name }} <${{ inputs.committer-email }}>"
+          title: "🧹 Update pinned tool versions"
+          branch: ${{ inputs.pr-branch }}
+          body: |
+            Automated update of pinned tool versions detected via `# auto-update:` annotations.
+
+            ${{ env.SUMMARY }}

--- a/.github/workflows/update-pinned-versions.yml
+++ b/.github/workflows/update-pinned-versions.yml
@@ -100,6 +100,8 @@ jobs:
           # Find all auto-update annotations.
           # Use process substitution to keep the loop in the current shell,
           # so writes to UPDATES_FILE are visible after the loop.
+          # Note: grep -oP (PCRE) is required. This is safe because the workflow
+          # is pinned to ubuntu-latest, which always ships GNU grep with PCRE.
           while IFS=: read -r file lineno _; do
             annotation=$(sed -n "${lineno}p" "$file")
             repo=$(echo "$annotation" | grep -oP '# auto-update: source=github-releases repo=\K\S+')
@@ -111,9 +113,11 @@ jobs:
 
             next_lineno=$((lineno + 1))
             version_line=$(sed -n "${next_lineno}p" "$file")
-            # Extract the first semver on the line — this is the actual value
+            # Extract the first strict semver on the line — this is the actual value
             # (e.g., "version: v2.0.0 # was v1.9.0" extracts v2.0.0).
-            current=$(echo "$version_line" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+            # Word boundaries (\b) prevent partial matches inside pre-release tags
+            # like v1.2.3-rc1 (which would otherwise extract v1.2.3).
+            current=$(echo "$version_line" | grep -oP '\bv[0-9]+\.[0-9]+\.[0-9]+\b' | head -1)
 
             if [ -z "$current" ]; then
               echo "::warning::No version found on line ${next_lineno} of ${file} (annotation for ${repo})"
@@ -160,12 +164,13 @@ jobs:
 
           # Apply updates using exact string matching.
           # Both $current and $latest are validated as strict semver (v0.0.0) above,
-          # so the only special character is '.'. We escape it for correctness.
+          # so the only special character is '.'. We escape dots in the pattern side.
+          # $latest needs no escaping — sed replacement side treats '.' as literal,
+          # and semver can't contain '&', '/', or '\' (the only special replacement chars).
           # The first-match-only replacement is intentional — the annotation contract
           # requires the version to appear exactly once on the annotated line.
           while IFS='|' read -r repo current latest file next_lineno; do
             escaped_current=$(printf '%s' "$current" | sed 's/[.]/\\./g')
-            # $latest is validated semver — no sed-special chars on the replacement side
             sed -i "${next_lineno}s/${escaped_current}/${latest}/" "$file"
             echo "Updated ${file}:${next_lineno}: ${current} -> ${latest}"
           done < "$UPDATES_FILE"


### PR DESCRIPTION
## Summary
- Adds a reusable workflow that scans workflow files for `# auto-update:` annotations and opens a PR when newer versions are available
- Zero third-party dependencies beyond `gh` CLI and `peter-evans/create-pull-request`
- Lightweight alternative to Renovate for pinned version strings in workflow files

Replaces #136 (closed due to stale bot review state).

## Annotation format
```yaml
# auto-update: source=github-releases repo=goreleaser/goreleaser
version: v2.15.3
```

## First consumer
mondoohq/mql#7260 (goreleaser version pinning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)