### PR TITLE
✨ Add xgrep SAST scanning action

### DIFF
--- a/.github/test_files/xgrep/vulnerable.py
+++ b/.github/test_files/xgrep/vulnerable.py
@@ -1,0 +1,17 @@
+"""Sample file with deliberate security issues to exercise the xgrep action."""
+
+import os
+import subprocess
+
+
+def run_command(user_input):
+    # Command injection: untrusted input passed to a shell.
+    os.system("echo " + user_input)
+    subprocess.call("ping " + user_input, shell=True)
+
+
+def connect():
+    # Hardcoded credentials / secret.
+    aws_access_key_id = "AKIAIOSFODNN7EXAMPLE"
+    aws_secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    return aws_access_key_id, aws_secret_access_key

--- a/.github/workflows/xgrep.yaml
+++ b/.github/workflows/xgrep.yaml
@@ -1,0 +1,26 @@
+name: Test xgrep scanning
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Run xgrep
+        uses: ./xgrep
+        with:
+          path: ./.github/test_files/xgrep
+          output-file: "custom-results.sarif"
+      - name: Archive SARIF results
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: xgrep-report
+          path: custom-results.sarif

--- a/.github/workflows/xgrep.yaml
+++ b/.github/workflows/xgrep.yaml
@@ -2,6 +2,10 @@ name: Test xgrep scanning
 
 on:
   pull_request:
+    paths:
+      - "xgrep/**"
+      - ".github/test_files/xgrep/**"
+      - ".github/workflows/xgrep.yaml"
   push:
     branches:
       - main

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .claude/settings.local.json
+.xgrep/
+*.sarif

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A set of GitHub Actions for using Mondoo to check for vulnerabilities and miscon
 - [Terraform HCL](terraform-hcl) - Scan HashiCorp Terraform HCL code for security misconfigurations.
 - [Terraform Plan](terraform-plan) - Scan HashiCorp Terraform Plan for security misconfigurations.
 - [Terraform State](terraform-state) - Scan HashiCorp Terraform State output for security misconfigurations.
+- [xgrep](xgrep) - Run xgrep SAST scanning and report findings to GitHub code scanning (no service account required).
 
 ## Service Accounts
 

--- a/xgrep/README.md
+++ b/xgrep/README.md
@@ -1,0 +1,86 @@
+# Mondoo xgrep Action
+
+A [GitHub Action](https://github.com/features/actions) that runs [xgrep](https://mondoo.com/docs/xgrep/), a Semgrep-compatible SAST scanner, and produces a [SARIF](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning) report so findings show up in GitHub code scanning.
+
+The action runs `xgrep ci`, which auto-detects the CI environment, scans **diff-aware** against the pull request base on PRs, and uses xgrep's built-in `security` and `secrets` rules by default. No Mondoo Platform service account or authentication is required.
+
+## Requirements
+
+- Node.js is required to install the `@mondoohq/xgrep` npm package. It is preinstalled on GitHub-hosted runners; on self-hosted runners add [`actions/setup-node`](https://github.com/actions/setup-node) before this action.
+- For diff-aware scanning on pull requests, check out the full git history with `fetch-depth: 0`.
+
+## Properties
+
+The xgrep Action has properties that are passed to the action using `with`.
+
+| Property         | Required | Default         | Description                                                                                             |
+| ---------------- | -------- | --------------- | ------------------------------------------------------------------------------------------------------- |
+| `path`           | false    | `.`             | Path(s) to scan.                                                                                        |
+| `rules`          | false    | `""`            | Path to a custom rule file or directory. When empty, xgrep's built-in security and secrets rules run.   |
+| `with-builtin`   | false    | `""`            | When `rules` is set, also run these built-in categories (comma-separated, e.g. `security,secrets`).     |
+| `output-file`    | false    | `results.sarif` | Path for the SARIF report file.                                                                         |
+| `version`        | false    | `latest`        | Version of the `@mondoohq/xgrep` npm package to install. Pin (e.g. `0.9.0`) for reproducible scans.     |
+| `sarif-category` | false    | `xgrep`         | SARIF category. Must match the `category` used when uploading the SARIF.                                |
+| `fail-on`        | false    | `off`           | Fail the job when findings exist at or above this severity: `off` (report only), `error`, or `warning`. |
+| `args`           | false    | `""`            | Extra raw flags passed through to `xgrep ci` (e.g. `--exclude vendor --decode`).                        |
+
+## Outputs
+
+| Output       | Description                         |
+| ------------ | ----------------------------------- |
+| `sarif-file` | Path to the generated SARIF report. |
+
+## Scan a repository for security issues
+
+```yaml
+name: xgrep
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write # required to upload SARIF
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # required for diff-aware scanning on pull requests
+      - name: Run xgrep
+        uses: mondoohq/actions/xgrep@v13.0.0
+        with:
+          path: .
+          output-file: "results.sarif"
+      - name: Upload SARIF results file
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: xgrep
+```
+
+## Fail the build on findings
+
+By default the action only reports findings to code scanning. To make the job fail when findings are present, set `fail-on`:
+
+```yaml
+- name: Run xgrep
+  uses: mondoohq/actions/xgrep@v13.0.0
+  with:
+    fail-on: error # or 'warning'
+```
+
+## Join the community!
+
+Join the [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions) to collaborate on policy as code and security automation.
+
+## License
+
+[Mozilla Public License v2.0](https://github.com/mondoohq/actions/blob/main/LICENSE)

--- a/xgrep/action.yaml
+++ b/xgrep/action.yaml
@@ -1,0 +1,98 @@
+name: "xgrep security scan"
+author: "mondoohq"
+description: "Run xgrep, a Semgrep-compatible SAST scanner, and output a SARIF report for GitHub code scanning"
+branding:
+  icon: "shield"
+  color: "purple"
+inputs:
+  path:
+    description: "Path(s) to scan"
+    required: false
+    default: "."
+  rules:
+    description: "Path to a custom rule file or directory. When empty, xgrep's built-in security and secrets rules are used."
+    required: false
+    default: ""
+  with-builtin:
+    description: "When 'rules' is set, additionally run these built-in rule categories (comma-separated, e.g. 'security,secrets')."
+    required: false
+    default: ""
+  output-file:
+    description: "Path for the SARIF report file"
+    required: false
+    default: "results.sarif"
+  version:
+    description: "Version of the @mondoohq/xgrep npm package to install (e.g. '0.9.0' or 'latest')"
+    required: false
+    default: "latest"
+  sarif-category:
+    description: "SARIF category (GitHub code scanning automationDetails.id). Must match the category used when uploading the SARIF."
+    required: false
+    default: "xgrep"
+  fail-on:
+    description: "Fail the job when findings exist at or above this severity: 'off' (report only), 'error', or 'warning'."
+    required: false
+    default: "off"
+  args:
+    description: "Extra raw flags passed through to 'xgrep ci' (e.g. '--exclude vendor --decode')."
+    required: false
+    default: ""
+outputs:
+  sarif-file:
+    description: "Path to the generated SARIF report"
+    value: ${{ inputs.output-file }}
+runs:
+  using: "composite"
+  steps:
+    - name: Install xgrep
+      shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: npm install -g "@mondoohq/xgrep@${INPUT_VERSION}"
+    - name: Run xgrep scan
+      shell: bash
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_RULES: ${{ inputs.rules }}
+        INPUT_WITH_BUILTIN: ${{ inputs.with-builtin }}
+        INPUT_OUTPUT_FILE: ${{ inputs.output-file }}
+        INPUT_SARIF_CATEGORY: ${{ inputs.sarif-category }}
+        INPUT_ARGS: ${{ inputs.args }}
+      run: |
+        set -euo pipefail
+        args=(ci --sarif-category "$INPUT_SARIF_CATEGORY" -o "$INPUT_OUTPUT_FILE")
+        if [ -n "$INPUT_RULES" ]; then
+          args+=(-c "$INPUT_RULES")
+          if [ -n "$INPUT_WITH_BUILTIN" ]; then
+            args+=(--with-builtin "$INPUT_WITH_BUILTIN")
+          fi
+        fi
+        if [ -n "$INPUT_ARGS" ]; then
+          read -ra extra <<<"$INPUT_ARGS"
+          args+=("${extra[@]}")
+        fi
+        args+=("$INPUT_PATH")
+        echo "Running: xgrep ${args[*]}"
+        xgrep "${args[@]}"
+    - name: Gate on findings
+      if: ${{ inputs.fail-on != 'off' }}
+      shell: bash
+      env:
+        INPUT_FAIL_ON: ${{ inputs.fail-on }}
+        INPUT_OUTPUT_FILE: ${{ inputs.output-file }}
+      run: |
+        set -euo pipefail
+        if [ ! -f "$INPUT_OUTPUT_FILE" ]; then
+          echo "::warning::SARIF file '$INPUT_OUTPUT_FILE' not found; skipping gate"
+          exit 0
+        fi
+        if [ "$INPUT_FAIL_ON" = "error" ]; then
+          count=$(jq '[.runs[].results[]? | select(.level == "error")] | length' "$INPUT_OUTPUT_FILE")
+        else
+          count=$(jq '[.runs[].results[]? | select(.level == "error" or .level == "warning")] | length' "$INPUT_OUTPUT_FILE")
+        fi
+        echo "Findings at or above '$INPUT_FAIL_ON': $count"
+        if [ "$count" -gt 0 ]; then
+          echo "::error::xgrep found $count finding(s) at or above severity '$INPUT_FAIL_ON'"
+          exit 1
+        fi


### PR DESCRIPTION
## What

Adds a reusable **composite** action that runs [xgrep](https://mondoo.com/docs/xgrep/) (a Semgrep-compatible SAST scanner) and emits a SARIF report for GitHub code scanning.

Unlike the existing Docker actions (on `mondoo/cnspec:13`), xgrep ships as an npm package (`@mondoohq/xgrep`), so this is a composite action that installs via npm and runs `xgrep ci`. `xgrep ci` auto-detects CI, scans **diff-aware** against the PR base, uses built-in `security`+`secrets` rules, and emits SARIF by default. **No service account / auth required.**

## Files

- **`xgrep/action.yaml`** — composite action:
  1. `npm install -g @mondoohq/xgrep@<version>`
  2. `xgrep ci` → SARIF (built-in rules, or a custom `rules` path)
  3. Optional severity gate (`fail-on: off|error|warning`) implemented as a `jq` level-count on the SARIF, so the **full** report still reaches code scanning even when gating.
- **`xgrep/README.md`** + root README entry.
- **`.github/workflows/xgrep.yaml`** + **`.github/test_files/xgrep/`** fixture — smoke test that scans a deliberately-vulnerable file and archives the SARIF.
- **`.gitignore`** — ignore xgrep's `.xgrep/` graph cache and `*.sarif` artifacts.

## Inputs

`path`, `rules`, `with-builtin`, `output-file`, `version` (default `latest` — pin for reproducibility), `sarif-category` (default `xgrep`, matches upload category), `fail-on` (default `off`), `args` (raw passthrough). Output: `sarif-file`.

## Verification

Validated locally with `xgrep v0.9.0`: the action's scan command produces a well-formed SARIF (category `xgrep`) and flags the fixture (2 command-injection findings). Gate jq logic verified: a synthetic SARIF with 1 error + 1 warning yields `fail-on=error → 1`, `fail-on=warning → 2`; the note-only fixture yields `0` for both. `action.yaml` parses as a valid composite action; all files pass `prettier --check`.

## Follow-up

Once merged and tagged (e.g. `vX.Y.0`), cnspec consumes this action via a companion PR (currently referencing `@main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)