### PR TITLE
⚡ ci: only run an action's tests when that action changes

### DIFF
--- a/.github/workflows/cnspec-lint.yaml
+++ b/.github/workflows/cnspec-lint.yaml
@@ -10,6 +10,7 @@ on:
     paths:
       - "cnspec-lint/**"
       - ".github/test_files/**"
+      - ".github/workflows/cnspec-lint.yaml"
     branches:
       - main
 

--- a/.github/workflows/cnspec-lint.yaml
+++ b/.github/workflows/cnspec-lint.yaml
@@ -2,6 +2,10 @@ name: Test cnspec policy linting
 
 on:
   pull_request:
+    paths:
+      - "cnspec-lint/**"
+      - ".github/test_files/cnspec-lint/**"
+      - ".github/workflows/cnspec-lint.yaml"
   push:
     branches:
       - main

--- a/.github/workflows/cnspec-lint.yaml
+++ b/.github/workflows/cnspec-lint.yaml
@@ -4,9 +4,12 @@ on:
   pull_request:
     paths:
       - "cnspec-lint/**"
-      - ".github/test_files/cnspec-lint/**"
+      - ".github/test_files/**"
       - ".github/workflows/cnspec-lint.yaml"
   push:
+    paths:
+      - "cnspec-lint/**"
+      - ".github/test_files/**"
     branches:
       - main
 

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -2,15 +2,14 @@ name: Docker Image Scanning
 on:
   pull_request:
     paths:
-      - "action.yaml"
       - "docker-image/**"
       - ".github/test_files/**"
       - ".github/workflows/docker-image.yaml"
   push:
     paths:
-      - "action.yaml"
       - "docker-image/**"
       - ".github/test_files/**"
+      - ".github/workflows/docker-image.yaml"
     branches:
       - "main"
     tags: ["v*.*.*"]

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -3,13 +3,13 @@ on:
   pull_request:
     paths:
       - "action.yaml"
-      - "docker-image/*"
+      - "docker-image/**"
       - ".github/test_files/**"
       - ".github/workflows/docker-image.yaml"
   push:
     paths:
       - "action.yaml"
-      - "docker-image/*"
+      - "docker-image/**"
       - ".github/test_files/**"
     branches:
       - "main"

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -1,6 +1,11 @@
 name: Docker Image Scanning
 on:
   pull_request:
+    paths:
+      - "action.yaml"
+      - "docker-image/*"
+      - ".github/test_files/**"
+      - ".github/workflows/docker-image.yaml"
   push:
     paths:
       - "action.yaml"

--- a/.github/workflows/general-action.yaml
+++ b/.github/workflows/general-action.yaml
@@ -9,6 +9,7 @@ on:
     paths:
       - "action.yaml"
       - ".github/test_files/**"
+      - ".github/workflows/general-action.yaml"
     branches:
       - "main"
     tags: ["v*.*.*"]

--- a/.github/workflows/general-action.yaml
+++ b/.github/workflows/general-action.yaml
@@ -1,6 +1,10 @@
 name: General Mondoo action
 on:
   pull_request:
+    paths:
+      - "action.yaml"
+      - ".github/test_files/**"
+      - ".github/workflows/general-action.yaml"
   push:
     paths:
       - "action.yaml"

--- a/.github/workflows/github-repo.yaml
+++ b/.github/workflows/github-repo.yaml
@@ -2,13 +2,12 @@ name: GitHub repo Scanning
 on:
   pull_request:
     paths:
-      - "action.yaml"
       - "github-repo/**"
       - ".github/workflows/github-repo.yaml"
   push:
     paths:
-      - "action.yaml"
       - "github-repo/**"
+      - ".github/workflows/github-repo.yaml"
     branches:
       - "main"
     tags: ["v*.*.*"]

--- a/.github/workflows/github-repo.yaml
+++ b/.github/workflows/github-repo.yaml
@@ -8,6 +8,7 @@ on:
   push:
     paths:
       - "action.yaml"
+      - "github-repo/**"
     branches:
       - "main"
     tags: ["v*.*.*"]

--- a/.github/workflows/github-repo.yaml
+++ b/.github/workflows/github-repo.yaml
@@ -1,6 +1,10 @@
 name: GitHub repo Scanning
 on:
   pull_request:
+    paths:
+      - "action.yaml"
+      - "github-repo/**"
+      - ".github/workflows/github-repo.yaml"
   push:
     paths:
       - "action.yaml"

--- a/.github/workflows/k8s-manifest.yaml
+++ b/.github/workflows/k8s-manifest.yaml
@@ -1,6 +1,11 @@
 name: K8s Manifest Scanning
 on:
   pull_request:
+    paths:
+      - "action.yaml"
+      - "k8s-manifest/*"
+      - ".github/test_files/**"
+      - ".github/workflows/k8s-manifest.yaml"
   push:
     paths:
       - "action.yaml"

--- a/.github/workflows/k8s-manifest.yaml
+++ b/.github/workflows/k8s-manifest.yaml
@@ -3,13 +3,13 @@ on:
   pull_request:
     paths:
       - "action.yaml"
-      - "k8s-manifest/*"
+      - "k8s-manifest/**"
       - ".github/test_files/**"
       - ".github/workflows/k8s-manifest.yaml"
   push:
     paths:
       - "action.yaml"
-      - "k8s-manifest/*"
+      - "k8s-manifest/**"
       - ".github/test_files/**"
     branches:
       - "main"

--- a/.github/workflows/k8s-manifest.yaml
+++ b/.github/workflows/k8s-manifest.yaml
@@ -2,15 +2,14 @@ name: K8s Manifest Scanning
 on:
   pull_request:
     paths:
-      - "action.yaml"
       - "k8s-manifest/**"
       - ".github/test_files/**"
       - ".github/workflows/k8s-manifest.yaml"
   push:
     paths:
-      - "action.yaml"
       - "k8s-manifest/**"
       - ".github/test_files/**"
+      - ".github/workflows/k8s-manifest.yaml"
     branches:
       - "main"
     tags: ["v*.*.*"]

--- a/.github/workflows/terraform-hcl.yaml
+++ b/.github/workflows/terraform-hcl.yaml
@@ -1,6 +1,11 @@
 name: Terraform HCL Scanning Tests
 on:
   pull_request:
+    paths:
+      - "action.yaml"
+      - "terraform-hcl/*"
+      - ".github/test_files/**"
+      - ".github/workflows/terraform-hcl.yaml"
   push:
     paths:
       - "action.yaml"

--- a/.github/workflows/terraform-hcl.yaml
+++ b/.github/workflows/terraform-hcl.yaml
@@ -2,15 +2,14 @@ name: Terraform HCL Scanning Tests
 on:
   pull_request:
     paths:
-      - "action.yaml"
       - "terraform-hcl/**"
       - ".github/test_files/**"
       - ".github/workflows/terraform-hcl.yaml"
   push:
     paths:
-      - "action.yaml"
       - "terraform-hcl/**"
       - ".github/test_files/**"
+      - ".github/workflows/terraform-hcl.yaml"
     branches:
       - "main"
     tags: ["v*.*.*"]

--- a/.github/workflows/terraform-hcl.yaml
+++ b/.github/workflows/terraform-hcl.yaml
@@ -3,13 +3,13 @@ on:
   pull_request:
     paths:
       - "action.yaml"
-      - "terraform-hcl/*"
+      - "terraform-hcl/**"
       - ".github/test_files/**"
       - ".github/workflows/terraform-hcl.yaml"
   push:
     paths:
       - "action.yaml"
-      - "terraform-hcl/*"
+      - "terraform-hcl/**"
       - ".github/test_files/**"
     branches:
       - "main"

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -2,15 +2,14 @@ name: Terraform Plan Scanning Tests
 on:
   pull_request:
     paths:
-      - "action.yaml"
       - "terraform-plan/**"
       - ".github/test_files/**"
       - ".github/workflows/terraform-plan.yaml"
   push:
     paths:
-      - "action.yaml"
       - "terraform-plan/**"
       - ".github/test_files/**"
+      - ".github/workflows/terraform-plan.yaml"
     branches:
       - "main"
     tags: ["v*.*.*"]

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -1,6 +1,12 @@
 name: Terraform Plan Scanning Tests
 on:
   pull_request:
+    paths:
+      - "action.yaml"
+      - "terraform-plan/*"
+      - "terraform-state/*"
+      - ".github/test_files/**"
+      - ".github/workflows/terraform-plan.yaml"
   push:
     paths:
       - "action.yaml"

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -3,15 +3,13 @@ on:
   pull_request:
     paths:
       - "action.yaml"
-      - "terraform-plan/*"
-      - "terraform-state/*"
+      - "terraform-plan/**"
       - ".github/test_files/**"
       - ".github/workflows/terraform-plan.yaml"
   push:
     paths:
       - "action.yaml"
-      - "terraform-plan/*"
-      - "terraform-state/*"
+      - "terraform-plan/**"
       - ".github/test_files/**"
     branches:
       - "main"

--- a/.github/workflows/terraform-state.yaml
+++ b/.github/workflows/terraform-state.yaml
@@ -2,15 +2,14 @@ name: Terraform State Scanning Tests
 on:
   pull_request:
     paths:
-      - "action.yaml"
       - "terraform-state/**"
       - ".github/test_files/**"
       - ".github/workflows/terraform-state.yaml"
   push:
     paths:
-      - "action.yaml"
       - "terraform-state/**"
       - ".github/test_files/**"
+      - ".github/workflows/terraform-state.yaml"
     branches:
       - "main"
     tags: ["v*.*.*"]

--- a/.github/workflows/terraform-state.yaml
+++ b/.github/workflows/terraform-state.yaml
@@ -3,15 +3,13 @@ on:
   pull_request:
     paths:
       - "action.yaml"
-      - "terraform-plan/*"
-      - "terraform-state/*"
+      - "terraform-state/**"
       - ".github/test_files/**"
       - ".github/workflows/terraform-state.yaml"
   push:
     paths:
       - "action.yaml"
-      - "terraform-plan/*"
-      - "terraform-state/*"
+      - "terraform-state/**"
       - ".github/test_files/**"
     branches:
       - "main"

--- a/.github/workflows/terraform-state.yaml
+++ b/.github/workflows/terraform-state.yaml
@@ -1,6 +1,12 @@
 name: Terraform State Scanning Tests
 on:
   pull_request:
+    paths:
+      - "action.yaml"
+      - "terraform-plan/*"
+      - "terraform-state/*"
+      - ".github/test_files/**"
+      - ".github/workflows/terraform-state.yaml"
   push:
     paths:
       - "action.yaml"


### PR DESCRIPTION
## What

Speeds up PR CI by running **only the test workflows for the actions a PR actually touches**, instead of running every action's test suite (Docker, Terraform plan/state/hcl, k8s, github-repo, cnspec-lint, general-action) on every PR.

## Why this works

Each action's test workflow already path-scopes its `push` trigger, but the `pull_request` trigger had **no `paths` filter** — so on PRs everything ran. This mirrors the existing `push` scoping onto `pull_request`.

Each workflow now triggers on:
- its own action directory (e.g. `terraform-hcl/*`),
- its test fixtures (`.github/test_files/**`, or the action-specific fixture dir),
- and its own workflow file.

## Safety

`main` has **no required status checks** (verified via the branch-protection API), so workflows that are skipped by a path filter don't leave a pending/blocking check on the PR.

Repo-wide checks (`fmt-check`, `link-check`, `spell-check`) are intentionally left running on every PR — they validate the whole repo, not a single action.

## Note

`xgrep.yaml` (added in #143) will get the same scoping in that PR / a follow-up so it's consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)