### PR TITLE
🔒 ci: pin GitHub Actions to latest SHAs (pinact --update)

### DIFF
--- a/.github/workflows/cnspec-lint.yaml
+++ b/.github/workflows/cnspec-lint.yaml
@@ -19,14 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Lint Policies
         uses: ./cnspec-lint
         with:
           path: ./.github/test_files/cnspec-lint
           output-file: "custom-results.sarif"
       - name: Archive SARIF results
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cnspec-lint-report
           path: custom-results.sarif

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Build and export to Docker
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ./.github/test_files/
           load: true

--- a/.github/workflows/fmt-check.yaml
+++ b/.github/workflows/fmt-check.yaml
@@ -10,8 +10,8 @@ jobs:
   format-actions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 16
       - name: Install Prettier

--- a/.github/workflows/general-action.yaml
+++ b/.github/workflows/general-action.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test general Mondoo action
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Show status
         uses: ./

--- a/.github/workflows/github-repo.yaml
+++ b/.github/workflows/github-repo.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test GitHub repo scanning
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Scan GitHub repo
         uses: ./github-repo
         env:

--- a/.github/workflows/k8s-manifest.yaml
+++ b/.github/workflows/k8s-manifest.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test k8s manifest scanning
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Scan k8s manifest
         uses: ./k8s-manifest
         env:

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: markdown-link-check
-        uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
+        uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # 1.0.17
         with:
           config-file: ".github/actions/link-check/config.json"
           use-verbose-mode: "yes"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Create release
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true

--- a/.github/workflows/released.yaml
+++ b/.github/workflows/released.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: "main"
           fetch-depth: 0

--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -7,5 +7,5 @@ jobs:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: crate-ci/typos@bbaefadf97b0ec5fdc942684b647f1a6ab250274 # v1.46.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2

--- a/.github/workflows/terraform-hcl.yaml
+++ b/.github/workflows/terraform-hcl.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Terraform scanning
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Scan Terraform HCL
         uses: ./terraform-hcl
         env:

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Terraform scanning
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # run terraform plan checks
-      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           # super important setting, otherwise you cannot pipe terraform show -json
           # see https://stackoverflow.com/questions/66496105/how-can-i-remove-all-the-extraneous-output-from-redirected-output-in-github-acti
@@ -37,7 +37,7 @@ jobs:
         run: terraform show -json plan > plan.json
         working-directory: ./.github/test_files/tfplan
       - name: Upload terraform plan
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: terraform-plan.json
           path: .github/test_files/tfplan/plan.json

--- a/.github/workflows/terraform-state.yaml
+++ b/.github/workflows/terraform-state.yaml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Terraform scanning
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # run terraform plan checks
-      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           # super important setting, otherwise you cannot pipe terraform show -json
           # see https://stackoverflow.com/questions/66496105/how-can-i-remove-all-the-extraneous-output-from-redirected-output-in-github-acti
@@ -43,7 +43,7 @@ jobs:
           terraform show -json terraform.tfstate > state.json
         working-directory: ./.github/test_files/tfstate
       - name: Upload terraform plan
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: terraform
           path: |

--- a/.github/workflows/update-pinned-versions.yml
+++ b/.github/workflows/update-pinned-versions.yml
@@ -88,14 +88,14 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ssh-key: ${{ secrets.ssh-key || '' }}
 
       # Fetch the script from this repo (mondoohq/actions), not from the caller repo.
       # This ensures the script version matches the workflow version.
       - name: Fetch update script
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: mondoohq/actions
           path: _actions
@@ -115,7 +115,7 @@ jobs:
 
       - name: Create pull request
         if: steps.scan.outputs.has_updates == 'true'
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           base: ${{ inputs.base-branch }}
           labels: dependencies

--- a/.github/workflows/xgrep.yaml
+++ b/.github/workflows/xgrep.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Run xgrep
@@ -24,7 +24,7 @@ jobs:
           path: ./.github/test_files/xgrep
           output-file: "custom-results.sarif"
       - name: Archive SARIF results
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: xgrep-report
           path: custom-results.sarif


### PR DESCRIPTION
## What

Ran `pinact run --update` to bump all third-party GitHub Actions to their latest releases, SHA-pinned with version comments. Pinning by immutable SHA (rather than mutable tags) mitigates tag-repointing supply-chain attacks; `--update` also picks up the newest releases.

## Notable bumps

- `actions/checkout` v6.0.2 → v6.0.3 (and the spell-check workflow's `v5.0.1 → v6.0.3`, now consistent with the rest of the repo)
- `softprops/action-gh-release` v2.6.1 → **v3.0.0** (major — used in `release.yaml`)
- `crate-ci/typos` v1.46.0 → v1.47.2
- `docker/build-push-action` v7.0.0 → v7.2.0, `docker/setup-buildx-action` v4.0.0 → v4.1.0, `docker/setup-qemu-action` v4.0.0 → v4.1.0
- `actions/setup-node` v6.3.0 → v6.4.0, `actions/upload-artifact` v7.0.0 → v7.0.1
- `hashicorp/setup-terraform` v4.0.0 → v4.0.1, `peter-evans/create-pull-request` v8.1.0 → v8.1.1
- `gaurav-nelson/github-action-markdown-link-check` floating `v1` → pinned `1.0.17`

## Supersedes dependabot PRs

This consolidates and supersedes the open dependabot bumps: #139, #140, #141, #142 — they can be closed once this merges.

## Verification

Only `uses:` lines changed (no logic). `prettier --check` passes (fmt-check unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)