### PR TITLE
✨ xgrep: print xgrep version before scanning

### DIFF
--- a/xgrep/action.yaml
+++ b/xgrep/action.yaml
@@ -60,6 +60,8 @@ runs:
         INPUT_ARGS: ${{ inputs.args }}
       run: |
         set -euo pipefail
+        echo "running xgrep version"
+        xgrep version
         args=(ci --sarif-category "$INPUT_SARIF_CATEGORY" -o "$INPUT_OUTPUT_FILE")
         if [ -n "$INPUT_RULES" ]; then
           args+=(-c "$INPUT_RULES")


### PR DESCRIPTION
Print the xgrep version before running the scan so it's visible in the action logs for debugging and reproducibility.

```bash
echo "running xgrep version"
xgrep version
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)