### PR TITLE
📝 Standardize action READMEs to match the xgrep template

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -1,27 +1,31 @@
 # Mondoo AWS Action
 
-A GitHub Action for using Mondoo to check for misconfigurations in your AWS accounts. This action can be used as a post-provisioning step when making changes to your AWS account.
+A [GitHub Action](https://github.com/features/actions) for using Mondoo to scan AWS accounts for security misconfigurations. This action can be used as a post-provisioning step when making changes to your AWS account.
+
+## Requirements
+
+- This is a Docker container action and runs only on Linux runners (e.g. `ubuntu-latest`).
+- A [Mondoo service account](https://mondoo.com/docs/maintain/access/non-human/service_accounts) is required to authenticate with Mondoo Platform (see `MONDOO_CONFIG_BASE64` below).
+- AWS credentials must be available to the runner, for example via [`aws-actions/configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials).
 
 ## Properties
 
-The Mondoo AWS Action has properties which are passed to the underlying image. These are passed to the action using `with`.
+The AWS Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
-| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
+| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
+| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
+| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 
-## Scan AWS account example
-
-You can use the AWS Action as follows:
+## Scan an AWS account
 
 ```yaml
 name: Scan AWS account
@@ -48,3 +52,11 @@ jobs:
           output: compact
           risk-threshold: 101
 ```
+
+## Join the community!
+
+Join the [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions) to collaborate on policy as code and security automation.
+
+## License
+
+[Mozilla Public License v2.0](https://github.com/mondoohq/actions/blob/main/LICENSE)

--- a/aws/README.md
+++ b/aws/README.md
@@ -13,16 +13,16 @@ A [GitHub Action](https://github.com/features/actions) for using Mondoo to scan 
 The AWS Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
-| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
+| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
+| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
+| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 
 ## Scan an AWS account

--- a/cnspec-lint/README.md
+++ b/cnspec-lint/README.md
@@ -1,6 +1,13 @@
 # Mondoo cnspec lint Action
 
-A [GitHub Action](https://github.com/features/actions) for linting cnspec policy bundles with SARIF output.
+A [GitHub Action](https://github.com/features/actions) that runs `cnspec bundle lint` on cnspec policy bundles and produces a [SARIF](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning) report so lint results show up in GitHub code scanning.
+
+No Mondoo Platform service account or authentication is required.
+
+## Requirements
+
+- This is a Docker container action and runs only on Linux runners (e.g. `ubuntu-latest`).
+- Uploading the SARIF report to GitHub code scanning requires the `security-events: write` permission.
 
 ## Properties
 
@@ -11,9 +18,7 @@ The cnspec lint Action has properties that are passed to the action using `with`
 | `path`        | true     | `.`             | Specifies the root path of the bundles.              |
 | `output-file` | true     | `results.sarif` | Specifies the output path for the SARIF report file. |
 
-## Scan policy bundles for lint errors
-
-You can use the Action as follows:
+## Lint policy bundles
 
 ```yaml
 name: Lint Policies
@@ -23,6 +28,10 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
+  security-events: write # required to upload SARIF
 
 jobs:
   build:
@@ -40,3 +49,11 @@ jobs:
         with:
           sarif_file: results.sarif
 ```
+
+## Join the community!
+
+Join the [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions) to collaborate on policy as code and security automation.
+
+## License
+
+[Mozilla Public License v2.0](https://github.com/mondoohq/actions/blob/main/LICENSE)

--- a/docker-image/README.md
+++ b/docker-image/README.md
@@ -13,17 +13,17 @@ A [GitHub Action](https://github.com/features/actions) for using Mondoo to scan 
 The Docker Image Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `image`                       | true     |         | Docker image ID or `name:tag` to scan.                                                                                                                                                                                |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
-| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
+| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `image`                       | true     |         | Docker image ID or `name:tag` to scan.                                                                                                                                                                                 |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
+| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
+| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 
 ## Build, scan, and push to GHCR.io

--- a/docker-image/README.md
+++ b/docker-image/README.md
@@ -1,28 +1,32 @@
-# Mondoo Docker Action
+# Mondoo Docker Image Action
 
-A GitHub Action for using Mondoo to check for vulnerabilities and misconfigurations in your Docker container images.
+A [GitHub Action](https://github.com/features/actions) for using Mondoo to scan Docker container images for vulnerabilities and misconfigurations before pushing to a container registry. This action supports both local images and images within remote registries.
+
+## Requirements
+
+- This is a Docker container action and runs only on Linux runners (e.g. `ubuntu-latest`).
+- A [Mondoo service account](https://mondoo.com/docs/maintain/access/non-human/service_accounts) is required to authenticate with Mondoo Platform (see `MONDOO_CONFIG_BASE64` below).
+- The image must be available to the runner: built and loaded locally, or in a registry the runner can reach (log in first for private registries).
 
 ## Properties
 
-The Mondoo Docker Image Action has properties which are passed to the underlying image. These are passed to the action using `with`.
+The Docker Image Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `image`                       | true     |         | Docker image ID or `name:tag` to scan.                                                                                                                                                                                 |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
-| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
+| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `image`                       | true     |         | Docker image ID or `name:tag` to scan.                                                                                                                                                                                |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
+| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
+| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 
-You can use the Action as follows:
-
-## Docker build scan and push to GHCR.io
+## Build, scan, and push to GHCR.io
 
 The following example uses the Docker [build-push-action](https://github.com/marketplace/actions/build-and-push-docker-images) to build a Docker container, scan the built container with Mondoo, and then push to ghcr.io. Use the `risk-threshold` property to ensure builds meet security requirements before publishing.
 
@@ -79,3 +83,11 @@ jobs:
       - name: Image Digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 ```
+
+## Join the community!
+
+Join the [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions) to collaborate on policy as code and security automation.
+
+## License
+
+[Mozilla Public License v2.0](https://github.com/mondoohq/actions/blob/main/LICENSE)

--- a/github-org/README.md
+++ b/github-org/README.md
@@ -1,44 +1,48 @@
 # Mondoo GitHub Organization Action
 
-A GitHub Action for using Mondoo to scan a GitHub Organization for security misconfigurations such as branch protection, CI tests, required code-review, and more. This Action can be used to audit a GitHub organization and its repositories. This Action can be easily used in [.github or .github-private](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile) repositories.
+A [GitHub Action](https://github.com/features/actions) for using Mondoo to scan a GitHub organization for security misconfigurations such as branch protection, CI tests, required code-review, and more. This action can be used to audit a GitHub organization and its repositories, and is easily used in [.github or .github-private](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile) repositories.
 
 **_Organizations with a large number of repositories (20+) are likely to hit GitHub's API Rate Limit causing this action to fail. Please refer to the 'Using App Tokens' section below!_**
+
+## Requirements
+
+- This is a Docker container action and runs only on Linux runners (e.g. `ubuntu-latest`).
+- A [Mondoo service account](https://mondoo.com/docs/maintain/access/non-human/service_accounts) is required to authenticate with Mondoo Platform (see `MONDOO_CONFIG_BASE64` below).
+- A GitHub token with read permissions is required (see the Permissions section below).
 
 ## Permissions
 
 Depending on the scope of the scan, you need to provide the proper permissions to the token. Since Mondoo only reads values, only read-only permissions are required.
 
 | Permission     | Description                                                                                  |
-| -------------- | -------------------------------------------------------------------------------------------- |
+| -------------- | ------------------------------------------------------------------------------------------- |
 | read:org       | e.g. required to verify GitHub organizations                                                 |
-| admin:org_hook | e.g. required to verify that all hooks use https                                             |
+| admin:org_hook | e.g. required to verify that all hooks use https                                            |
 | repo           | Ability to read configuration, required since GitHub does not provide a repo:read permission |
-| workflow       | e.g. allows the verification of workflow settings                                            |
-| read:packages  | e.g. allows you to verify that packages are not public                                       |
+| workflow       | e.g. allows the verification of workflow settings                                           |
+| read:packages  | e.g. allows you to verify that packages are not public                                      |
 
 ## Properties
 
-The GitHub Organization Action has properties which are passed to the underlying image. These are passed to the action using `with`.
+The GitHub Organization Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `organization`                | true     |         | GitHub organization to scan eg. `mondoohq`.                                                                                                                                                                            |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
-| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
-| `is-cicd`                     | false    | true    | Flag to disable the auto-detection for CI/CD runs. If deactivated it reports into the Fleet view                                                                                                                       |
+| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `organization`                | true     |         | GitHub organization to scan eg. `mondoohq`.                                                                                                                                                                           |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
+| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
+| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
+| `is-cicd`                     | false    | true    | Flag to disable the auto-detection for CI/CD runs. If deactivated it reports into the Fleet view.                                                                                                                     |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
-Additionally, you need to specify the service account and GitHub credentials as an environment variable.
+Additionally, you need to specify the service account and GitHub credentials as environment variables.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 | `GITHUB_TOKEN`         | true     |         | GitHub token used for authentication                                                                                                                       |
 
-## Scan GitHub organization
-
-You can use the Action as follows:
+## Scan a GitHub organization
 
 ```yaml
 name: Scan GitHub organization
@@ -54,7 +58,7 @@ jobs:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          organization: ${{ GITHUB_REPOSITORY_OWNER }}
+          organization: ${{ github.repository_owner }}
 ```
 
 ## Using App Tokens
@@ -74,7 +78,7 @@ To leverage an App Token:
 9. Now, select **Install App** and then **Install** next to the Org you're planning to scan. You can choose All Repositories or only the repo running this action, then select **Install**.
 10. Finally, update your action to include the github-app-token action and use its output token. This will require you to add the App ID and Private Key to Action Secrets. The new action will look like:
 
-```
+```yaml
 # ....
     steps:
       - uses: actions/checkout@v5
@@ -92,3 +96,11 @@ To leverage an App Token:
           organization: <YOUR_ORGANIZATION>
           is-cicd: false
 ```
+
+## Join the community!
+
+Join the [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions) to collaborate on policy as code and security automation.
+
+## License
+
+[Mozilla Public License v2.0](https://github.com/mondoohq/actions/blob/main/LICENSE)

--- a/github-org/README.md
+++ b/github-org/README.md
@@ -15,30 +15,30 @@ A [GitHub Action](https://github.com/features/actions) for using Mondoo to scan 
 Depending on the scope of the scan, you need to provide the proper permissions to the token. Since Mondoo only reads values, only read-only permissions are required.
 
 | Permission     | Description                                                                                  |
-| -------------- | ------------------------------------------------------------------------------------------- |
+| -------------- | -------------------------------------------------------------------------------------------- |
 | read:org       | e.g. required to verify GitHub organizations                                                 |
-| admin:org_hook | e.g. required to verify that all hooks use https                                            |
+| admin:org_hook | e.g. required to verify that all hooks use https                                             |
 | repo           | Ability to read configuration, required since GitHub does not provide a repo:read permission |
-| workflow       | e.g. allows the verification of workflow settings                                           |
-| read:packages  | e.g. allows you to verify that packages are not public                                      |
+| workflow       | e.g. allows the verification of workflow settings                                            |
+| read:packages  | e.g. allows you to verify that packages are not public                                       |
 
 ## Properties
 
 The GitHub Organization Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `organization`                | true     |         | GitHub organization to scan eg. `mondoohq`.                                                                                                                                                                           |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
-| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
-| `is-cicd`                     | false    | true    | Flag to disable the auto-detection for CI/CD runs. If deactivated it reports into the Fleet view.                                                                                                                     |
+| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `organization`                | true     |         | GitHub organization to scan eg. `mondoohq`.                                                                                                                                                                            |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
+| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
+| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
+| `is-cicd`                     | false    | true    | Flag to disable the auto-detection for CI/CD runs. If deactivated it reports into the Fleet view.                                                                                                                      |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account and GitHub credentials as environment variables.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 | `GITHUB_TOKEN`         | true     |         | GitHub token used for authentication                                                                                                                       |
 
@@ -80,21 +80,21 @@ To leverage an App Token:
 
 ```yaml
 # ....
-    steps:
-      - uses: actions/checkout@v5
-      - name: Generate token
-        id: generate_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: mondoohq/actions/github-org@v13.0.0
-        env:
-          MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-        with:
-          organization: <YOUR_ORGANIZATION>
-          is-cicd: false
+steps:
+  - uses: actions/checkout@v5
+  - name: Generate token
+    id: generate_token
+    uses: actions/create-github-app-token@v1
+    with:
+      app-id: ${{ secrets.APP_ID }}
+      private-key: ${{ secrets.APP_PRIVATE_KEY }}
+  - uses: mondoohq/actions/github-org@v13.0.0
+    env:
+      MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
+      GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+    with:
+      organization: <YOUR_ORGANIZATION>
+      is-cicd: false
 ```
 
 ## Join the community!

--- a/github-repo/README.md
+++ b/github-repo/README.md
@@ -13,28 +13,28 @@ A [GitHub Action](https://github.com/features/actions) for using Mondoo to scan 
 Depending on the scope of the scan, you need to provide the proper permissions to the token. Since Mondoo only reads values, only read-only permissions are required.
 
 | Permission    | Description                                                                                  |
-| ------------- | ------------------------------------------------------------------------------------------- |
+| ------------- | -------------------------------------------------------------------------------------------- |
 | repo          | Ability to read configuration, required since GitHub does not provide a repo:read permission |
-| workflow      | e.g. allows the verification of workflow settings                                           |
-| read:packages | e.g. allows you to verify that packages are not public                                      |
+| workflow      | e.g. allows the verification of workflow settings                                            |
+| read:packages | e.g. allows you to verify that packages are not public                                       |
 
 ## Properties
 
 The GitHub Repository Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `repository`                  | true     |         | GitHub repository to scan eg. `mondoohq/actions`.                                                                                                                                                                     |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
-| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
-| `is-cicd`                     | false    | true    | Flag to disable the auto-detection for CI/CD runs. If deactivated it reports into the Fleet view.                                                                                                                     |
+| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `repository`                  | true     |         | GitHub repository to scan eg. `mondoohq/actions`.                                                                                                                                                                      |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
+| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
+| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
+| `is-cicd`                     | false    | true    | Flag to disable the auto-detection for CI/CD runs. If deactivated it reports into the Fleet view.                                                                                                                      |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account and GitHub credentials as environment variables.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 | `GITHUB_TOKEN`         | true     |         | GitHub token used for authentication                                                                                                                       |
 

--- a/github-repo/README.md
+++ b/github-repo/README.md
@@ -1,41 +1,44 @@
 # Mondoo GitHub Repository Action
 
-A GitHub Action for using Mondoo to scan GitHub repositories for security misconfigurations such as branch protection, CI tests, required code-review, and more. This Action can be used to audit individual GitHub repositories.
+A [GitHub Action](https://github.com/features/actions) for using Mondoo to scan a GitHub repository for security misconfigurations such as branch protection, CI tests, required code-review, and more. This action can be used to audit individual GitHub repositories.
+
+## Requirements
+
+- This is a Docker container action and runs only on Linux runners (e.g. `ubuntu-latest`).
+- A [Mondoo service account](https://mondoo.com/docs/maintain/access/non-human/service_accounts) is required to authenticate with Mondoo Platform (see `MONDOO_CONFIG_BASE64` below).
+- A GitHub token with read permissions is required (see the Permissions section below).
 
 ## Permissions
 
 Depending on the scope of the scan, you need to provide the proper permissions to the token. Since Mondoo only reads values, only read-only permissions are required.
 
 | Permission    | Description                                                                                  |
-| ------------- | -------------------------------------------------------------------------------------------- |
+| ------------- | ------------------------------------------------------------------------------------------- |
 | repo          | Ability to read configuration, required since GitHub does not provide a repo:read permission |
-| workflow      | e.g. allows the verification of workflow settings                                            |
-| read:packages | e.g. allows you to verify that packages are not public                                       |
+| workflow      | e.g. allows the verification of workflow settings                                           |
+| read:packages | e.g. allows you to verify that packages are not public                                      |
 
 ## Properties
 
-The GitHub repository Action has properties that are passed to the action using `with`.
+The GitHub Repository Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `repository`                  | true     |         | GitHub Repository eg. `mondoohq/actions`                                                                                                                                                                               |
-| `token`                       | true     |         | GitHub token used for authentication                                                                                                                                                                                   |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
-| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
+| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `repository`                  | true     |         | GitHub repository to scan eg. `mondoohq/actions`.                                                                                                                                                                     |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
+| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
+| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
+| `is-cicd`                     | false    | true    | Flag to disable the auto-detection for CI/CD runs. If deactivated it reports into the Fleet view.                                                                                                                     |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
-| `is-cicd`                     | false    | true    | Flag to disable the auto-detection for CI/CD runs. If deactivated it reports into the Fleet view                                                                                                                       |
 
-Additionally, you need to specify the service account and GitHub credentials as an environment variable.
+Additionally, you need to specify the service account and GitHub credentials as environment variables.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 | `GITHUB_TOKEN`         | true     |         | GitHub token used for authentication                                                                                                                       |
 
-## Scan GitHub Repository
-
-You can use the Action as follows:
+## Scan a GitHub repository
 
 ```yaml
 name: Scan GitHub repository
@@ -51,5 +54,13 @@ jobs:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          repository: ${{ GITHUB_REPOSITORY }}
+          repository: ${{ github.repository }}
 ```
+
+## Join the community!
+
+Join the [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions) to collaborate on policy as code and security automation.
+
+## License
+
+[Mozilla Public License v2.0](https://github.com/mondoohq/actions/blob/main/LICENSE)

--- a/k8s-manifest/README.md
+++ b/k8s-manifest/README.md
@@ -1,30 +1,34 @@
 # Mondoo Kubernetes Manifest Action
 
-A GitHub Action for using Mondoo to scan Kubernetes manifests for security misconfigurations.
+A [GitHub Action](https://github.com/features/actions) for using Mondoo to scan Kubernetes manifests for security misconfigurations before applying changes to the cluster.
 
 For Kubernetes cluster scanning see Mondoo's [k8s](../k8s/) action.
 
+## Requirements
+
+- This is a Docker container action and runs only on Linux runners (e.g. `ubuntu-latest`).
+- A [Mondoo service account](https://mondoo.com/docs/maintain/access/non-human/service_accounts) is required to authenticate with Mondoo Platform (see `MONDOO_CONFIG_BASE64` below).
+- The manifest file must be checked out into the workspace (use [`actions/checkout`](https://github.com/actions/checkout)).
+
 ## Properties
 
-The Kubernetes Manifest Action has properties which are passed to the underlying image. These are passed to the action using `with`.
+The Kubernetes Manifest Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
-| `path`                        | true     |         | Path to Kubernetes manifest file.                                                                                                                                                                                      |
-| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
+| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
+| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
+| `path`                        | true     |         | Path to the Kubernetes manifest file.                                                                                                                                                                                 |
+| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 
-## Scan Kubernetes manifests with Mondoo
-
-You can use the Action as follows:
+## Scan a Kubernetes manifest
 
 ```yaml
 name: Mondoo Kubernetes Manifest scan
@@ -43,3 +47,11 @@ jobs:
         with:
           path: k8s/deployment.yaml
 ```
+
+## Join the community!
+
+Join the [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions) to collaborate on policy as code and security automation.
+
+## License
+
+[Mozilla Public License v2.0](https://github.com/mondoohq/actions/blob/main/LICENSE)

--- a/k8s-manifest/README.md
+++ b/k8s-manifest/README.md
@@ -15,17 +15,17 @@ For Kubernetes cluster scanning see Mondoo's [k8s](../k8s/) action.
 The Kubernetes Manifest Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
-| `path`                        | true     |         | Path to the Kubernetes manifest file.                                                                                                                                                                                 |
-| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
+| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
+| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
+| `path`                        | true     |         | Path to the Kubernetes manifest file.                                                                                                                                                                                  |
+| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 
 ## Scan a Kubernetes manifest

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -15,16 +15,16 @@ For Kubernetes manifest scanning see Mondoo's [k8s-manifest](../k8s-manifest/) a
 The Kubernetes Cluster Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
-| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
+| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
+| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
+| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 
 ## Scan a Kubernetes cluster

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,29 +1,33 @@
 # Mondoo Kubernetes Cluster Action
 
-A GitHub Action for using Mondoo to scan Kubernetes clusters for security vulnerabilities and misconfigurations. This Action can be used as a post-deploy job to provide continuous auditing of your cluster. This action requires a valid `KUBECONFIG` with access to the cluster(s) to be scanned.
+A [GitHub Action](https://github.com/features/actions) for using Mondoo to scan Kubernetes clusters for security vulnerabilities and misconfigurations. This action can be used as a post-deploy job to provide continuous auditing of your cluster.
 
 For Kubernetes manifest scanning see Mondoo's [k8s-manifest](../k8s-manifest/) action.
 
+## Requirements
+
+- This is a Docker container action and runs only on Linux runners (e.g. `ubuntu-latest`).
+- A [Mondoo service account](https://mondoo.com/docs/maintain/access/non-human/service_accounts) is required to authenticate with Mondoo Platform (see `MONDOO_CONFIG_BASE64` below).
+- A valid `KUBECONFIG` with access to the cluster(s) to be scanned must be available to the runner.
+
 ## Properties
 
-The Kubernetes Cluster Action has properties which are passed to the underlying image. These are passed to the action using `with`.
+The Kubernetes Cluster Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
-| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
+| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
+| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
+| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 
-## Scan Kubernetes cluster
-
-You can use the Action as follows:
+## Scan a Kubernetes cluster
 
 ```yaml
 name: Scan Kubernetes cluster
@@ -41,3 +45,11 @@ jobs:
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
 ```
+
+## Join the community!
+
+Join the [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions) to collaborate on policy as code and security automation.
+
+## License
+
+[Mozilla Public License v2.0](https://github.com/mondoohq/actions/blob/main/LICENSE)

--- a/policy/README.md
+++ b/policy/README.md
@@ -18,15 +18,15 @@ Adding policies to Mondoo Platform requires a [Mondoo service account](https://m
 The Policy Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
-| `path`                        | true     |         | Path to the policy file.                                                                                                                                                                                              |
+| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
+| `path`                        | true     |         | Path to the policy file.                                                                                                                                                                                               |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 
 ## Add a policy to Mondoo Platform

--- a/policy/README.md
+++ b/policy/README.md
@@ -1,6 +1,11 @@
 # Mondoo Policy Action
 
-A GitHub Action for publishing Mondoo policies to Mondoo Platform.
+A [GitHub Action](https://github.com/features/actions) for publishing Mondoo policies to Mondoo Platform.
+
+## Requirements
+
+- This is a Docker container action and runs only on Linux runners (e.g. `ubuntu-latest`).
+- A [Mondoo service account](https://mondoo.com/docs/maintain/access/non-human/service_accounts) with **elevated (Space Gateway Agent)** permissions is required to add policies to Mondoo Platform (see below).
 
 ## Service Account Permissions
 
@@ -10,23 +15,21 @@ Adding policies to Mondoo Platform requires a [Mondoo service account](https://m
 
 ## Properties
 
-The Mondoo Policy Action has properties which are passed to the underlying image. These are passed to the action using `with`.
+The Policy Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
-| `path`                        | true     |         | Path to the policy file.                                                                                                                                                                                               |
+| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
+| `path`                        | true     |         | Path to the policy file.                                                                                                                                                                                              |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 
 ## Add a policy to Mondoo Platform
-
-You can use the Action as follows:
 
 ```yaml
 name: Mondoo Policy Add Example
@@ -45,3 +48,11 @@ jobs:
         with:
           path: policy/policy.yml
 ```
+
+## Join the community!
+
+Join the [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions) to collaborate on policy as code and security automation.
+
+## License
+
+[Mozilla Public License v2.0](https://github.com/mondoohq/actions/blob/main/LICENSE)

--- a/terraform-hcl/README.md
+++ b/terraform-hcl/README.md
@@ -2,27 +2,31 @@
 
 A [GitHub Action](https://github.com/features/actions) for testing [HashiCorp Terraform](https://developer.hashicorp.com/terraform) [HCL code](https://developer.hashicorp.com/terraform/language/syntax/configuration) for security misconfigurations.
 
+## Requirements
+
+- This is a Docker container action and runs only on Linux runners (e.g. `ubuntu-latest`).
+- A [Mondoo service account](https://mondoo.com/docs/maintain/access/non-human/service_accounts) is required to authenticate with Mondoo Platform (see `MONDOO_CONFIG_BASE64` below).
+- The Terraform HCL files must be checked out into the workspace (use [`actions/checkout`](https://github.com/actions/checkout)).
+
 ## Properties
 
-The Terraform Action has properties which are passed to the underlying image. These are passed to the action using `with`.
+The Terraform HCL Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
-| `path`                        | true     |         | Path to the Terraform working directory.                                                                                                                                                                               |
-| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
+| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
+| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
+| `path`                        | true     |         | Path to the Terraform working directory.                                                                                                                                                                              |
+| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 
-## Scan Terraform working directory
-
-You can use the Action as follows:
+## Scan a Terraform working directory
 
 ```yaml
 name: Mondoo Terraform scan
@@ -41,3 +45,11 @@ jobs:
         with:
           path: terraform
 ```
+
+## Join the community!
+
+Join the [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions) to collaborate on policy as code and security automation.
+
+## License
+
+[Mozilla Public License v2.0](https://github.com/mondoohq/actions/blob/main/LICENSE)

--- a/terraform-hcl/README.md
+++ b/terraform-hcl/README.md
@@ -13,17 +13,17 @@ A [GitHub Action](https://github.com/features/actions) for testing [HashiCorp Te
 The Terraform HCL Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
-| `path`                        | true     |         | Path to the Terraform working directory.                                                                                                                                                                              |
-| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
+| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
+| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
+| `path`                        | true     |         | Path to the Terraform working directory.                                                                                                                                                                               |
+| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 
 ## Scan a Terraform working directory

--- a/terraform-plan/README.md
+++ b/terraform-plan/README.md
@@ -2,26 +2,32 @@
 
 A [GitHub Action](https://github.com/features/actions) for testing [HashiCorp Terraform](https://developer.hashicorp.com/terraform) plan files for security misconfigurations. Plan files must be saved in JSON format before they are scanned.
 
+## Requirements
+
+- This is a Docker container action and runs only on Linux runners (e.g. `ubuntu-latest`).
+- A [Mondoo service account](https://mondoo.com/docs/maintain/access/non-human/service_accounts) is required to authenticate with Mondoo Platform (see `MONDOO_CONFIG_BASE64` below).
+- A Terraform plan saved in JSON format (`terraform show -json`) must be available to the runner.
+
 ## Properties
 
-The Terraform Action has properties which are passed to the underlying image. These are passed to the action using `with`.
+The Terraform Plan Action has properties that are passed to the action using `with`.
 
-| Property                      | Required | Default     | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log-level`                   | false    | info        | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
-| `output`                      | false    | compact     | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
-| `path`                        | false    | ./terraform | Path to the Terraform working directory (default "./terraform")                                                                                                                                                        |
-| `path-file`                   | false    | plan.json   | Name of plan file to scan (default "plan.json")                                                                                                                                                                        |
-| `risk-threshold`              | false    | 101         | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
-| `service-account-credentials` | false    |             | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
+| Property                      | Required | Default   | Description                                                                                                                                                                                                            |
+| ----------------------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log-level`                   | false    | info      | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
+| `output`                      | false    | compact   | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
+| `path`                        | false    | terraform | Path to the directory containing the plan file.                                                                                                                                                                       |
+| `plan-file`                   | false    | plan.json | Name of the JSON plan file to scan.                                                                                                                                                                                   |
+| `risk-threshold`              | false    | 101       | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
+| `service-account-credentials` | false    |           | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 
-## Scan Terraform plan file
+## Scan a Terraform plan file
 
 The following example uses HashiCorp's [setup-terraform](https://github.com/hashicorp/setup-terraform) to generate a Terraform plan file and convert it to JSON before running a scan with cnspec.
 
@@ -65,3 +71,11 @@ jobs:
           path: terraform
           plan-file: plan.json
 ```
+
+## Join the community!
+
+Join the [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions) to collaborate on policy as code and security automation.
+
+## License
+
+[Mozilla Public License v2.0](https://github.com/mondoohq/actions/blob/main/LICENSE)

--- a/terraform-plan/README.md
+++ b/terraform-plan/README.md
@@ -13,18 +13,18 @@ A [GitHub Action](https://github.com/features/actions) for testing [HashiCorp Te
 The Terraform Plan Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default   | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log-level`                   | false    | info      | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
-| `output`                      | false    | compact   | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
-| `path`                        | false    | terraform | Path to the directory containing the plan file.                                                                                                                                                                       |
-| `plan-file`                   | false    | plan.json | Name of the JSON plan file to scan.                                                                                                                                                                                   |
-| `risk-threshold`              | false    | 101       | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
+| ----------------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log-level`                   | false    | info      | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
+| `output`                      | false    | compact   | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
+| `path`                        | false    | terraform | Path to the directory containing the plan file.                                                                                                                                                                        |
+| `plan-file`                   | false    | plan.json | Name of the JSON plan file to scan.                                                                                                                                                                                    |
+| `risk-threshold`              | false    | 101       | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
 | `service-account-credentials` | false    |           | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 
 ## Scan a Terraform plan file

--- a/terraform-state/README.md
+++ b/terraform-state/README.md
@@ -2,27 +2,31 @@
 
 A [GitHub Action](https://github.com/features/actions) for testing [HashiCorp Terraform](https://developer.hashicorp.com/terraform) state files for security misconfigurations.
 
+## Requirements
+
+- This is a Docker container action and runs only on Linux runners (e.g. `ubuntu-latest`).
+- A [Mondoo service account](https://mondoo.com/docs/maintain/access/non-human/service_accounts) is required to authenticate with Mondoo Platform (see `MONDOO_CONFIG_BASE64` below).
+- The Terraform state must be available in the workspace.
+
 ## Properties
 
-The Terraform Action has properties which are passed to the underlying image. These are passed to the action using `with`.
+The Terraform State Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
-| `path`                        | true     |         | Path to the Terraform working directory.                                                                                                                                                                               |
-| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
+| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
+| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
+| `path`                        | true     |         | Path to the Terraform working directory.                                                                                                                                                                              |
+| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 
-## Scan Terraform working directory
-
-You can use the Action as follows:
+## Scan a Terraform state file
 
 ```yaml
 name: Mondoo Terraform State scan
@@ -41,3 +45,11 @@ jobs:
         with:
           path: terraform
 ```
+
+## Join the community!
+
+Join the [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions) to collaborate on policy as code and security automation.
+
+## License
+
+[Mozilla Public License v2.0](https://github.com/mondoohq/actions/blob/main/LICENSE)

--- a/terraform-state/README.md
+++ b/terraform-state/README.md
@@ -13,17 +13,17 @@ A [GitHub Action](https://github.com/features/actions) for testing [HashiCorp Te
 The Terraform State Action has properties that are passed to the action using `with`.
 
 | Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                  |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                    |
-| `path`                        | true     |         | Path to the Terraform working directory.                                                                                                                                                                              |
-| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                  |
+| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
+| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
+| `path`                        | true     |         | Path to the Terraform working directory.                                                                                                                                                                               |
+| `risk-threshold`              | false    | 101     | If any risk is greater or equal to this, exit status is 1. (default "0" - job continues regardless of the score returned by a scan).                                                                                   |
 | `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
 | Environment            | Required | Default | Description                                                                                                                                                |
-| ---------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MONDOO_CONFIG_BASE64` | true     |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform |
 
 ## Scan a Terraform state file


### PR DESCRIPTION
## What

Rewrites all 11 action READMEs to a consistent structure modeled on the `xgrep` README (the "gold" template):

- **Intro** — `A [GitHub Action](https://github.com/features/actions) …`
- **`## Requirements`** — added everywhere: runner OS constraint (these are Docker container actions → Linux runners only) plus per-action prerequisites (service account, `KUBECONFIG`, GitHub token, JSON plan, `security-events: write`, etc.)
- **`## Properties`** — standardized sentence ("…properties that are passed to the action using `with`.")
- **`## Join the community!`** + **`## License`** footers — added to all

`xgrep/README.md` is unchanged (it's the template).

## Doc-accuracy fixes found while cross-checking against `action.yaml`

Every documented option was verified against the real `inputs:` in each `action.yaml` **and** against which inputs are actually wired into `runs/args`. Corrections:

- **github-org** — `${{ GITHUB_REPOSITORY_OWNER }}` → `${{ github.repository_owner }}` (the former resolves to empty inside a `${{ }}` expression)
- **github-repo** — `${{ GITHUB_REPOSITORY }}` → `${{ github.repository }}`, and removed a documented `token` property that doesn't exist in `action.yaml` (auth is via the `GITHUB_TOKEN` env var)
- **terraform-plan** — `path-file` → `plan-file` (the real input name), and aligned the `path` default with `action.yaml` (`terraform`)

## Verification

All documented options are valid and correct — for 11 of 12 actions, the set is consistent three ways: **documented == declared == actually used**.

## Follow-ups (not in this PR)

- **`policy/action.yaml` declares an `output` input that is never wired into the command** (`bundle upload … --log-level …` ignores it). The README correctly omits it; the dead input should be removed from `action.yaml`.
- Docker scanners don't expose an `args` passthrough or SARIF output — tracked separately as feature work.
- READMEs still pin `@v13.0.0` while tags have advanced to `v13.2.0`; consider a moving `v13` major tag so docs stop drifting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)