### PR TITLE
📝 Bump README pins to v13.2.0 and fix release automation

### DIFF
--- a/.github/workflows/released.yaml
+++ b/.github/workflows/released.yaml
@@ -6,42 +6,74 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version that was released"
+        description: "Version to write into the READMEs (e.g. v13.2.0)"
         required: true
-        default: "v1.2.3"
+        default: "v13.2.0"
+
+# main is protected and requires changes to land via a pull request, so this
+# workflow opens a PR instead of pushing to main directly.
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-readme-pins
+  cancel-in-progress: false
 
 jobs:
   update-version:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: "main"
           fetch-depth: 0
-      - name: Version from Workflow Dispatch
-        if: github.event_name == 'workflow_dispatch'
+
+      - name: Resolve version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
-      - name: Version from Release Tag
-        if: github.event_name == 'release'
-        run: |
-          echo "VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
-      - name: Verify valid version
-        id: vars
-        run: |
-          if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid version: $VERSION"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="$RELEASE_TAG"
+          fi
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version: $VERSION"
             exit 1
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-      - name: Find and Replace
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Update README version pins
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          find . -type f -name 'README.md' -exec sed -i -E "s/(mondoohq\/.+@).+$/\1${VERSION}/g" {} \;
-      - name: Commit READMEs
+          find . -type f -name 'README.md' -print0 \
+            | xargs -0 sed -i -E "s#(mondoohq/actions/[a-z0-9-]+@)v[0-9]+\.[0-9]+\.[0-9]+#\1${VERSION}#g"
+
+      - name: Open pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          git add .
-          git config --global user.email "tools@mondoo.com"
-          git config --global user.name "Mondoo Tools"
-          git commit -m "Update READMEs with released version $VERSION"
-          git push -f
+          if git diff --quiet; then
+            echo "READMEs already pin ${VERSION}; nothing to update."
+            exit 0
+          fi
+          BRANCH="ci/readme-pins-${VERSION}"
+          git config user.name "Mondoo Tools"
+          git config user.email "tools@mondoo.com"
+          git switch -c "$BRANCH" 2>/dev/null || git switch "$BRANCH"
+          git commit -am "📝 docs: update README version pins to ${VERSION}"
+          git push -u origin "$BRANCH" --force-with-lease
+          if gh pr view "$BRANCH" >/dev/null 2>&1; then
+            echo "PR already open for ${BRANCH}; it has been updated."
+          else
+            gh pr create --base main --head "$BRANCH" \
+              --title "📝 docs: update README version pins to ${VERSION}" \
+              --body "Automated update of \`mondoohq/actions/*@\` version pins in the READMEs to **${VERSION}**, triggered by the ${VERSION} release."
+          fi

--- a/.github/workflows/released.yaml
+++ b/.github/workflows/released.yaml
@@ -53,7 +53,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           find . -type f -name 'README.md' -print0 \
-            | xargs -0 sed -i -E "s#(mondoohq/actions/[a-z0-9-]+@)v[0-9]+\.[0-9]+\.[0-9]+#\1${VERSION}#g"
+            | xargs -0 sed -i -E "s#(mondoohq/actions(/[a-z0-9-]+)?@)v[0-9]+\.[0-9]+\.[0-9]+#\1${VERSION}#g"
 
       - name: Open pull request
         env:
@@ -67,8 +67,15 @@ jobs:
           BRANCH="ci/readme-pins-${VERSION}"
           git config user.name "Mondoo Tools"
           git config user.email "tools@mondoo.com"
-          git switch -c "$BRANCH" 2>/dev/null || git switch "$BRANCH"
-          git commit -am "📝 docs: update README version pins to ${VERSION}"
+          # -C creates the branch or resets it if a prior run left one behind.
+          git switch -C "$BRANCH"
+          # Stage READMEs explicitly so newly added ones are included too.
+          git add -- '*README.md'
+          if git diff --cached --quiet; then
+            echo "No staged README changes; nothing to commit."
+            exit 0
+          fi
+          git commit -m "📝 docs: update README version pins to ${VERSION}"
           git push -u origin "$BRANCH" --force-with-lease
           if gh pr view "$BRANCH" >/dev/null 2>&1; then
             echo "PR already open for ${BRANCH}; it has been updated."

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: mondoohq/actions/k8s-manifest@v13.0.0
+      - uses: mondoohq/actions/k8s-manifest@v13.2.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         with:
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: mondoohq/actions/terraform-hcl@v13.0.0
+      - uses: mondoohq/actions/terraform-hcl@v13.2.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         with:
@@ -119,7 +119,7 @@ jobs:
             ghcr.io/${{github.repository_owner}}/${{env.APP}}:${{env.VERSION}}
           secrets: GIT_AUTH_TOKEN=${{ secrets.GIT_AUTH_TOKEN }}
       - name: Scan Docker Image with Mondoo
-        uses: mondoohq/actions/docker-image@v13.0.0
+        uses: mondoohq/actions/docker-image@v13.2.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         with:

--- a/aws/README.md
+++ b/aws/README.md
@@ -45,7 +45,7 @@ jobs:
           role-to-assume: arn:aws:iam::123456789100:role/my-github-actions-role
           role-session-name: MySessionName
 
-      - uses: mondoohq/actions/aws@v13.0.0
+      - uses: mondoohq/actions/aws@v13.2.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         with:

--- a/cnspec-lint/README.md
+++ b/cnspec-lint/README.md
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
       - name: Lint Policies
-        uses: mondoohq/actions/cnspec-lint@v13.0.0
+        uses: mondoohq/actions/cnspec-lint@v13.2.0
         with:
           path: .
           output-file: "results.sarif"

--- a/docker-image/README.md
+++ b/docker-image/README.md
@@ -66,7 +66,7 @@ jobs:
             ghcr.io/${{github.repository_owner}}/${{env.APP}}:${{env.VERSION}}
           secrets: GIT_AUTH_TOKEN=${{ secrets.GIT_AUTH_TOKEN }}
       - name: Scan Docker Image
-        uses: mondoohq/actions/docker-image@v13.0.0
+        uses: mondoohq/actions/docker-image@v13.2.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         with:

--- a/github-org/README.md
+++ b/github-org/README.md
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: mondoohq/actions/github-org@v13.0.0
+      - uses: mondoohq/actions/github-org@v13.2.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -88,7 +88,7 @@ steps:
     with:
       app-id: ${{ secrets.APP_ID }}
       private-key: ${{ secrets.APP_PRIVATE_KEY }}
-  - uses: mondoohq/actions/github-org@v13.0.0
+  - uses: mondoohq/actions/github-org@v13.2.0
     env:
       MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
       GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/github-repo/README.md
+++ b/github-repo/README.md
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: mondoohq/actions/github-repo@v13.0.0
+      - uses: mondoohq/actions/github-repo@v13.2.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/k8s-manifest/README.md
+++ b/k8s-manifest/README.md
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: mondoohq/actions/k8s-manifest@v13.0.0
+      - uses: mondoohq/actions/k8s-manifest@v13.2.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         with:

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: mondoohq/actions/k8s@v13.0.0
+      - uses: mondoohq/actions/k8s@v13.2.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
 ```

--- a/policy/README.md
+++ b/policy/README.md
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: mondoohq/actions/policy@v13.0.0
+      - uses: mondoohq/actions/policy@v13.2.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         with:

--- a/terraform-hcl/README.md
+++ b/terraform-hcl/README.md
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: mondoohq/actions/terraform-hcl@v13.0.0
+      - uses: mondoohq/actions/terraform-hcl@v13.2.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         with:

--- a/terraform-plan/README.md
+++ b/terraform-plan/README.md
@@ -64,7 +64,7 @@ jobs:
         continue-on-error: true
 
       - name: Scan Terraform plan file for security misconfigurations
-        uses: mondoohq/actions/terraform-plan@v13.0.0
+        uses: mondoohq/actions/terraform-plan@v13.2.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         with:

--- a/terraform-state/README.md
+++ b/terraform-state/README.md
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: mondoohq/actions/terraform-state@v13.0.0
+      - uses: mondoohq/actions/terraform-state@v13.2.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         with:

--- a/xgrep/README.md
+++ b/xgrep/README.md
@@ -54,7 +54,7 @@ jobs:
         with:
           fetch-depth: 0 # required for diff-aware scanning on pull requests
       - name: Run xgrep
-        uses: mondoohq/actions/xgrep@v13.0.0
+        uses: mondoohq/actions/xgrep@v13.2.0
         with:
           path: .
           output-file: "results.sarif"
@@ -72,7 +72,7 @@ By default the action only reports findings to code scanning. To make the job fa
 
 ```yaml
 - name: Run xgrep
-  uses: mondoohq/actions/xgrep@v13.0.0
+  uses: mondoohq/actions/xgrep@v13.2.0
   with:
     fail-on: error # or 'warning'
 ```


### PR DESCRIPTION
## What

1. **Bumps every `mondoohq/actions/*@` README pin from `v13.0.0` → `v13.2.0`** (the current latest release).
2. **Fixes the release automation** so this stops drifting on its own.

## Why the automation was broken

The `Update READMEs with released Version` workflow has **failed on every release since v12.0.0**. It fired correctly on the `released` event, but the final step force-pushed to `main`, which is protected by a ruleset requiring PRs:

```
remote: - Changes must be made through a pull request.
 ! [remote rejected] main -> main (push declined due to repository rule violations)
```

That's why the READMEs were stuck at `v13.0.0` while tags advanced to `v13.2.0`.

## The fix

Rework the workflow to **open a PR instead of pushing to `main`**:

- Pushes a `ci/readme-pins-<version>` branch and opens a PR via the preinstalled `gh` CLI (no new third-party action to pin).
- Resolves the version through `env:` variables instead of interpolating `github` context into the `run:` block — closes a shell-injection vector (flagged by Semgrep) while still validating against a semver regex.
- Tightens the `sed` to only rewrite `mondoohq/actions/<name>@<semver>` pins (the old `s/(mondoohq\/.+@).+$/…/` was greedy).
- No-ops cleanly when the READMEs already pin the released version.
- Adds `contents`/`pull-requests` permissions and a `concurrency` group.

## Verification

- `prettier --check .` passes.
- `released.yaml` parses as valid YAML; `github` context now appears only in `env:` mappings.
- All 17 README pins now read `@v13.2.0`.

> Note: PRs opened by the default `GITHUB_TOKEN` don't retrigger `pull_request` workflows, so the auto-PR won't run the format check — acceptable here since the change is version-string-only. If you'd prefer full auto-merge, add the workflow's token/app to the ruleset bypass list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)