### PR TITLE
📝 Update third-party action versions in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: mondoohq/actions/k8s-manifest@v13.0.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
@@ -72,7 +72,7 @@ jobs:
   scan-tf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: mondoohq/actions/terraform-hcl@v13.0.0
         env:
@@ -98,19 +98,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to GHCR.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
       - name: Build and export to Docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -125,7 +125,7 @@ jobs:
         with:
           image: ghcr.io/${{github.repository_owner}}/${{env.APP}}:latest
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           tags: |
@@ -163,7 +163,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test k8s manifest scanning
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Scan k8s manifest
         uses: ./k8s-manifest
@@ -188,7 +188,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test k8s manifest scanning
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Scan k8s manifest
         uses: ./k8s-manifest
@@ -237,7 +237,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Check whether tests are enabled for this PR
@@ -262,7 +262,7 @@ jobs:
         # Here we add a comment to the PR that states whether the tests are running or not. This is an optional step.
         # We have it for clarification. It does not add new comments for every change. It will edit the existing comment instead.
       - name: Update PR comment
-        uses: mshick/add-pr-comment@v2
+        uses: mshick/add-pr-comment@v3
         if: always()
         with:
           message: |

--- a/aws/README.md
+++ b/aws/README.md
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::123456789100:role/my-github-actions-role

--- a/cnspec-lint/README.md
+++ b/cnspec-lint/README.md
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Lint Policies
         uses: mondoohq/actions/cnspec-lint@v13.0.0
         with:

--- a/docker-image/README.md
+++ b/docker-image/README.md
@@ -45,19 +45,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to GHCR.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
       - name: Build and export to Docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -72,7 +72,7 @@ jobs:
         with:
           image: ghcr.io/${{github.repository_owner}}/${{env.APP}}:latest
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           tags: |

--- a/github-org/README.md
+++ b/github-org/README.md
@@ -52,7 +52,7 @@ jobs:
   scan-github-org:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: mondoohq/actions/github-org@v13.0.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
@@ -81,10 +81,10 @@ To leverage an App Token:
 ```yaml
 # ....
 steps:
-  - uses: actions/checkout@v5
+  - uses: actions/checkout@v7
   - name: Generate token
     id: generate_token
-    uses: actions/create-github-app-token@v1
+    uses: actions/create-github-app-token@v3
     with:
       app-id: ${{ secrets.APP_ID }}
       private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/github-repo/README.md
+++ b/github-repo/README.md
@@ -48,7 +48,7 @@ jobs:
   scan-github-repo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: mondoohq/actions/github-repo@v13.0.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}

--- a/k8s-manifest/README.md
+++ b/k8s-manifest/README.md
@@ -40,7 +40,7 @@ jobs:
   scan-k8s-manifest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: mondoohq/actions/k8s-manifest@v13.0.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -40,7 +40,7 @@ jobs:
   scan-k8s-cluster:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: mondoohq/actions/k8s@v13.0.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}

--- a/policy/README.md
+++ b/policy/README.md
@@ -41,7 +41,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: mondoohq/actions/policy@v13.0.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}

--- a/terraform-hcl/README.md
+++ b/terraform-hcl/README.md
@@ -38,7 +38,7 @@ jobs:
   scan-tf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: mondoohq/actions/terraform-hcl@v13.0.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}

--- a/terraform-plan/README.md
+++ b/terraform-plan/README.md
@@ -47,8 +47,8 @@ jobs:
   generate-and-scan-terraform-plan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: hashicorp/setup-terraform@v3
+      - uses: actions/checkout@v7
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_wrapper: false
 

--- a/terraform-state/README.md
+++ b/terraform-state/README.md
@@ -38,7 +38,7 @@ jobs:
   scan-tf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: mondoohq/actions/terraform-state@v13.0.0
         env:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}

--- a/xgrep/README.md
+++ b/xgrep/README.md
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # required for diff-aware scanning on pull requests
       - name: Run xgrep


### PR DESCRIPTION
The example workflows in the READMEs pinned several third-party actions to major versions that are multiple releases behind (e.g. `actions/checkout@v5`, now `v7`). Each has been bumped to the **current latest major**, verified against the actual upstream project — I checked both the latest GitHub release and confirmed the major moving tag exists.

| Action | Was | Now | Latest release verified |
| --- | --- | --- | --- |
| `actions/checkout` | v5 | **v7** | v7.0.0 |
| `actions/create-github-app-token` | v1 | **v3** | v3.2.0 |
| `aws-actions/configure-aws-credentials` | v4 | **v6** | v6.2.1 |
| `docker/build-push-action` | v6 | **v7** | v7.3.0 |
| `docker/login-action` | v3 | **v4** | v4.2.0 |
| `docker/setup-buildx-action` | v3 | **v4** | v4.1.0 |
| `docker/setup-qemu-action` | v3 | **v4** | v4.2.0 |
| `hashicorp/setup-terraform` | v3 | **v4** | v4.0.1 |
| `mshick/add-pr-comment` | v2 | **v3** | v3.12.0 |
| `github/codeql-action/upload-sarif` | v3 | _v3 (unchanged)_ | already latest major |

Only the third-party `uses:` pins in example blocks changed; `mondoohq/actions/*` pins are untouched (handled in #152). `prettier --check` passes.

> Note: these are static examples, so they'll drift again over time. Dependabot's `github-actions` ecosystem only scans real workflow files under `.github/workflows`, not fenced code blocks in Markdown — so keeping these fresh is a periodic manual task unless we add tooling for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)