### PR TITLE
✨ Add SARIF output to the Terraform scan actions

### DIFF
--- a/.github/workflows/terraform-hcl.yaml
+++ b/.github/workflows/terraform-hcl.yaml
@@ -26,3 +26,16 @@ jobs:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         with:
           path: ./.github/test_files/tf
+      - name: Scan Terraform HCL (SARIF)
+        uses: ./terraform-hcl
+        env:
+          MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
+        with:
+          path: ./.github/test_files/tf
+          output: sarif
+          output-file: results.sarif
+      - name: Archive SARIF results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: terraform-hcl-report
+          path: results.sarif

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -48,3 +48,17 @@ jobs:
         with:
           path: ".github/test_files/tfplan/"
           plan-file: plan.json
+      - name: Scan Terraform Plan (SARIF)
+        uses: ./terraform-plan
+        env:
+          MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
+        with:
+          path: ".github/test_files/tfplan/"
+          plan-file: plan.json
+          output: sarif
+          output-file: results.sarif
+      - name: Archive SARIF results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: terraform-plan-report
+          path: results.sarif

--- a/.github/workflows/terraform-state.yaml
+++ b/.github/workflows/terraform-state.yaml
@@ -55,3 +55,16 @@ jobs:
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
         with:
           path: ".github/test_files/tfstate/state.json"
+      - name: Scan Terraform State (SARIF)
+        uses: ./terraform-state
+        env:
+          MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
+        with:
+          path: ".github/test_files/tfstate/state.json"
+          output: sarif
+          output-file: results.sarif
+      - name: Archive SARIF results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: terraform-state-report
+          path: results.sarif

--- a/terraform-hcl/README.md
+++ b/terraform-hcl/README.md
@@ -12,13 +12,14 @@ A [GitHub Action](https://github.com/features/actions) for testing [HashiCorp Te
 
 The Terraform HCL Action has properties that are passed to the action using `with`.
 
-| Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
-| `path`                        | true     |         | Path to the Terraform working directory.                                                                                                                                                                               |
-| `risk-threshold`              | false    | 101     | Fail the job (exit status 1) if any risk score is greater than or equal to this value. Risk scores range from 0 to 100, so the default of "101" never fails the job.                                                   |
-| `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
+| Property                      | Required | Default       | Description                                                                                                                                                                                                            |
+| ----------------------------- | -------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log-level`                   | false    | info          | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
+| `output`                      | false    | compact       | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report, sarif (default "compact")                                                                                              |
+| `output-file`                 | false    | results.sarif | Path to write the scan report to. Combine with `output: sarif` to produce a SARIF report you can upload to GitHub code scanning.                                                                                       |
+| `path`                        | true     |               | Path to the Terraform working directory.                                                                                                                                                                               |
+| `risk-threshold`              | false    | 101           | Fail the job (exit status 1) if any risk score is greater than or equal to this value. Risk scores range from 0 to 100, so the default of "101" never fails the job.                                                   |
+| `service-account-credentials` | false    |               | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
@@ -45,6 +46,42 @@ jobs:
         with:
           path: terraform
 ```
+
+## Report findings to GitHub code scanning
+
+Set `output: sarif` to write a [SARIF](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning) report, then upload it so findings appear in the repository's Security tab and on pull requests.
+
+```yaml
+name: Mondoo Terraform scan
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write # required to upload SARIF
+
+jobs:
+  scan-tf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: mondoohq/actions/terraform-hcl@v13.3.0
+        env:
+          MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
+        with:
+          path: terraform
+          output: sarif
+          output-file: results.sarif
+      - name: Upload SARIF results file
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: results.sarif
+```
+
+> The `--output-file` is always written (default `results.sarif`); it only contains SARIF when `output: sarif` is set. Leave `output` at its default to keep the human-readable console output.
 
 ## Join the community!
 

--- a/terraform-hcl/README.md
+++ b/terraform-hcl/README.md
@@ -81,7 +81,7 @@ jobs:
           sarif_file: results.sarif
 ```
 
-> The `--output-file` is always written (default `results.sarif`); it only contains SARIF when `output: sarif` is set. Leave `output` at its default to keep the human-readable console output.
+> The report file is always written (default `results.sarif`, via cnspec's `--output-target`); it contains SARIF only when `output: sarif` is set.
 
 ## Join the community!
 

--- a/terraform-hcl/action.yaml
+++ b/terraform-hcl/action.yaml
@@ -43,7 +43,7 @@ runs:
     - ${{ inputs.risk-threshold }}
     - --log-level
     - ${{ inputs.log-level }}
-    - --output-file
+    - --output-target
     - ${{ inputs.output-file }}
   env:
     MONDOO_CONFIG_BASE64: ${{ inputs.service-account-credentials }}

--- a/terraform-hcl/action.yaml
+++ b/terraform-hcl/action.yaml
@@ -11,8 +11,13 @@ inputs:
     required: false
   output:
     description: >-
-      Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")
+      Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report, sarif (default "compact")
     default: compact
+    required: false
+  output-file:
+    description: >-
+      Path to write the scan report to. Combine with `output: sarif` to produce a SARIF report you can upload to GitHub code scanning.
+    default: results.sarif
     required: false
   path:
     description: Path to the Terraform working directory.
@@ -38,5 +43,7 @@ runs:
     - ${{ inputs.risk-threshold }}
     - --log-level
     - ${{ inputs.log-level }}
+    - --output-file
+    - ${{ inputs.output-file }}
   env:
     MONDOO_CONFIG_BASE64: ${{ inputs.service-account-credentials }}

--- a/terraform-plan/README.md
+++ b/terraform-plan/README.md
@@ -12,14 +12,15 @@ A [GitHub Action](https://github.com/features/actions) for testing [HashiCorp Te
 
 The Terraform Plan Action has properties that are passed to the action using `with`.
 
-| Property                      | Required | Default   | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log-level`                   | false    | info      | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
-| `output`                      | false    | compact   | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
-| `path`                        | false    | terraform | Path to the directory containing the plan file.                                                                                                                                                                        |
-| `plan-file`                   | false    | plan.json | Name of the JSON plan file to scan.                                                                                                                                                                                    |
-| `risk-threshold`              | false    | 101       | Fail the job (exit status 1) if any risk score is greater than or equal to this value. Risk scores range from 0 to 100, so the default of "101" never fails the job.                                                   |
-| `service-account-credentials` | false    |           | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
+| Property                      | Required | Default       | Description                                                                                                                                                                                                            |
+| ----------------------------- | -------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log-level`                   | false    | info          | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
+| `output`                      | false    | compact       | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report, sarif (default "compact")                                                                                              |
+| `output-file`                 | false    | results.sarif | Path to write the scan report to. Combine with `output: sarif` to produce a SARIF report you can upload to GitHub code scanning.                                                                                       |
+| `path`                        | false    | terraform     | Path to the directory containing the plan file.                                                                                                                                                                        |
+| `plan-file`                   | false    | plan.json     | Name of the JSON plan file to scan.                                                                                                                                                                                    |
+| `risk-threshold`              | false    | 101           | Fail the job (exit status 1) if any risk score is greater than or equal to this value. Risk scores range from 0 to 100, so the default of "101" never fails the job.                                                   |
+| `service-account-credentials` | false    |               | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
@@ -71,6 +72,29 @@ jobs:
           path: terraform
           plan-file: plan.json
 ```
+
+## Report findings to GitHub code scanning
+
+Set `output: sarif` to write a [SARIF](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning) report, then upload it so findings appear in the repository's Security tab and on pull requests.
+
+```yaml
+- name: Scan Terraform plan file for security misconfigurations
+  uses: mondoohq/actions/terraform-plan@v13.3.0
+  env:
+    MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
+  with:
+    path: terraform
+    plan-file: plan.json
+    output: sarif
+    output-file: results.sarif
+- name: Upload SARIF results file
+  uses: github/codeql-action/upload-sarif@v3
+  if: always()
+  with:
+    sarif_file: results.sarif
+```
+
+> The job needs `permissions: security-events: write` to upload SARIF. The action runs at the workspace root (the `defaults.run.working-directory` above only affects `run:` steps), so `--output-file results.sarif` is written there. It only contains SARIF when `output: sarif` is set; leave `output` at its default to keep the human-readable console output.
 
 ## Join the community!
 

--- a/terraform-plan/README.md
+++ b/terraform-plan/README.md
@@ -94,7 +94,7 @@ Set `output: sarif` to write a [SARIF](https://docs.github.com/en/code-security/
     sarif_file: results.sarif
 ```
 
-> The job needs `permissions: security-events: write` to upload SARIF. The action runs at the workspace root (the `defaults.run.working-directory` above only affects `run:` steps), so `--output-file results.sarif` is written there. It only contains SARIF when `output: sarif` is set; leave `output` at its default to keep the human-readable console output.
+> The job needs `permissions: security-events: write` to upload SARIF. The action runs at the workspace root (the `defaults.run.working-directory` above only affects `run:` steps), so the report file (default `results.sarif`, via cnspec's `--output-target`) is written there. It contains SARIF only when `output: sarif` is set.
 
 ## Join the community!
 

--- a/terraform-plan/action.yaml
+++ b/terraform-plan/action.yaml
@@ -11,8 +11,13 @@ inputs:
     required: false
   output:
     description: >-
-      Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")
+      Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report, sarif (default "compact")
     default: compact
+    required: false
+  output-file:
+    description: >-
+      Path to write the scan report to. Combine with `output: sarif` to produce a SARIF report you can upload to GitHub code scanning.
+    default: results.sarif
     required: false
   path:
     description: Path to the directory containing the plan file.
@@ -44,5 +49,7 @@ runs:
     - ${{ inputs.risk-threshold }}
     - --log-level
     - ${{ inputs.log-level }}
+    - --output-file
+    - ${{ inputs.output-file }}
   env:
     MONDOO_CONFIG_BASE64: ${{ inputs.service-account-credentials }}

--- a/terraform-plan/action.yaml
+++ b/terraform-plan/action.yaml
@@ -49,7 +49,7 @@ runs:
     - ${{ inputs.risk-threshold }}
     - --log-level
     - ${{ inputs.log-level }}
-    - --output-file
+    - --output-target
     - ${{ inputs.output-file }}
   env:
     MONDOO_CONFIG_BASE64: ${{ inputs.service-account-credentials }}

--- a/terraform-state/README.md
+++ b/terraform-state/README.md
@@ -81,7 +81,7 @@ jobs:
           sarif_file: results.sarif
 ```
 
-> The `--output-file` is always written (default `results.sarif`); it only contains SARIF when `output: sarif` is set. Leave `output` at its default to keep the human-readable console output.
+> The report file is always written (default `results.sarif`, via cnspec's `--output-target`); it contains SARIF only when `output: sarif` is set.
 
 ## Join the community!
 

--- a/terraform-state/README.md
+++ b/terraform-state/README.md
@@ -12,13 +12,14 @@ A [GitHub Action](https://github.com/features/actions) for testing [HashiCorp Te
 
 The Terraform State Action has properties that are passed to the action using `with`.
 
-| Property                      | Required | Default | Description                                                                                                                                                                                                            |
-| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log-level`                   | false    | info    | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
-| `output`                      | false    | compact | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")                                                                                                     |
-| `path`                        | true     |         | Path to the Terraform working directory.                                                                                                                                                                               |
-| `risk-threshold`              | false    | 101     | Fail the job (exit status 1) if any risk score is greater than or equal to this value. Risk scores range from 0 to 100, so the default of "101" never fails the job.                                                   |
-| `service-account-credentials` | false    |         | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
+| Property                      | Required | Default       | Description                                                                                                                                                                                                            |
+| ----------------------------- | -------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log-level`                   | false    | info          | Sets the log level: error, warn, info, debug, trace (default "info")                                                                                                                                                   |
+| `output`                      | false    | compact       | Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report, sarif (default "compact")                                                                                              |
+| `output-file`                 | false    | results.sarif | Path to write the scan report to. Combine with `output: sarif` to produce a SARIF report you can upload to GitHub code scanning.                                                                                       |
+| `path`                        | true     |               | Path to the Terraform working directory.                                                                                                                                                                               |
+| `risk-threshold`              | false    | 101           | Fail the job (exit status 1) if any risk score is greater than or equal to this value. Risk scores range from 0 to 100, so the default of "101" never fails the job.                                                   |
+| `service-account-credentials` | false    |               | Base64 encoded [service account credentials](https://mondoo.com/docs/maintain/access/non-human/service_accounts) used to authenticate with Mondoo Platform. You can also use the environment variable mentioned below. |
 
 Additionally, you need to specify the service account credentials as an environment variable.
 
@@ -45,6 +46,42 @@ jobs:
         with:
           path: terraform
 ```
+
+## Report findings to GitHub code scanning
+
+Set `output: sarif` to write a [SARIF](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning) report, then upload it so findings appear in the repository's Security tab and on pull requests.
+
+```yaml
+name: Mondoo Terraform State scan
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write # required to upload SARIF
+
+jobs:
+  scan-tf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: mondoohq/actions/terraform-state@v13.3.0
+        env:
+          MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
+        with:
+          path: terraform
+          output: sarif
+          output-file: results.sarif
+      - name: Upload SARIF results file
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: results.sarif
+```
+
+> The `--output-file` is always written (default `results.sarif`); it only contains SARIF when `output: sarif` is set. Leave `output` at its default to keep the human-readable console output.
 
 ## Join the community!
 

--- a/terraform-state/action.yaml
+++ b/terraform-state/action.yaml
@@ -11,8 +11,13 @@ inputs:
     required: false
   output:
     description: >-
-      Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report (default "compact")
+      Set the output format for scan results: compact, yaml, json, junit, csv, summary, full, report, sarif (default "compact")
     default: compact
+    required: false
+  output-file:
+    description: >-
+      Path to write the scan report to. Combine with `output: sarif` to produce a SARIF report you can upload to GitHub code scanning.
+    default: results.sarif
     required: false
   path:
     description: Path to the Terraform working directory.
@@ -39,5 +44,7 @@ runs:
     - ${{ inputs.risk-threshold }}
     - --log-level
     - ${{ inputs.log-level }}
+    - --output-file
+    - ${{ inputs.output-file }}
   env:
     MONDOO_CONFIG_BASE64: ${{ inputs.service-account-credentials }}

--- a/terraform-state/action.yaml
+++ b/terraform-state/action.yaml
@@ -44,7 +44,7 @@ runs:
     - ${{ inputs.risk-threshold }}
     - --log-level
     - ${{ inputs.log-level }}
-    - --output-file
+    - --output-target
     - ${{ inputs.output-file }}
   env:
     MONDOO_CONFIG_BASE64: ${{ inputs.service-account-credentials }}


### PR DESCRIPTION
cnspec `scan` now supports SARIF output for Terraform, so this wires it into `terraform-hcl`, `terraform-plan`, and `terraform-state` — letting findings flow into the GitHub Security tab and PR annotations, the way `cnspec-lint` and `xgrep` already do.

## Changes per action

- New **`output-file`** input (default `results.sarif`); `--output-file ${{ inputs.output-file }}` is appended to the cnspec args.
- Users opt into code scanning by setting `output: sarif` and uploading the file with `github/codeql-action/upload-sarif`.
- Kept as Docker-container actions (per design discussion) — no execution-model change.

## Usage

```yaml
permissions:
  contents: read
  security-events: write
steps:
  - uses: actions/checkout@v7
  - uses: mondoohq/actions/terraform-hcl@v13.3.0
    env:
      MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_SERVICE_ACCOUNT }}
    with:
      path: terraform
      output: sarif
      output-file: results.sarif
  - uses: github/codeql-action/upload-sarif@v3
    if: always()
    with:
      sarif_file: results.sarif
```

## Docs
All three READMEs get an `output-file` row, `sarif` added to the format list, and a "Report findings to GitHub code scanning" section (with the required `security-events: write` note).

## Tests
Each `terraform-*` test workflow now runs a **second** scan with `output: sarif` and archives the report as an artifact (same pattern as the xgrep/cnspec-lint tests). This keeps the original default-output step, so CI verifies both that SARIF is produced **and** that the always-passed `--output-file` doesn't break the default (compact) run.

## Known trade-off
Because a Docker-container action can't conditionally add a flag, `--output-file` is always passed (default `results.sarif`). With the default `output: compact` the file just holds compact text — harmless if unused. If cnspec's `--output-file` turns out to *suppress* console output, that would be a behavior change for default users; the new CI step will surface it, and I'll flag before merge if so. Documented inline in each README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)